### PR TITLE
feat: support new model windows (Sonnet/Opus/Flash Lite) and improve Gemini reset logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,24 @@ Example `model-selector.json`:
 ```
 
 In this example, the Copilot Chat mapping has a reserve of 20%. This means the model selector will only use that model when more than 20% quota remains, preserving at least 20% for other purposes.
+
+### Provider Settings
+
+Some providers support additional settings:
+
+#### Gemini
+
+- `resetTimezone`: The fallback timezone used to calculate daily reset times if the API doesn't provide them. 
+  - `"local"`: Uses your machine's local time.
+  - IANA Timezone ID: e.g., `"America/New_York"`, `"Europe/London"`.
+  - Default: `"America/Los_Angeles"`.
+
+```json
+{
+  "providerSettings": {
+    "gemini": {
+      "resetTimezone": "local"
+    }
+  }
+}
+```

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/config/model-selector.example.json
+++ b/config/model-selector.example.json
@@ -19,6 +19,9 @@
   "providerSettings": {
     "minimax": {
       "groupId": "1234567890"
+    },
+    "gemini": {
+      "resetTimezone": "local"
     }
   },
   "mappings": [

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -30,11 +30,37 @@ Windows are dynamically determined based on the `modelId` returned by the API:
 
 - **Pro**: Groups models with "pro" in their ID (e.g., `gemini-1.5-pro`).
 - **Flash**: Groups models with "flash" in their ID (e.g., `gemini-1.5-flash`).
+- **Flash Lite**: Groups models with "flash-lite" in their ID (e.g., `gemini-3.1-flash-lite-preview`).
 - **Other**: Default group for other model IDs.
 
 ## Reset Time
 
-Gemini API quotas reset daily at **midnight Pacific Time**. Since the API does not return reset timestamps, the extension computes the next midnight in `America/Los_Angeles` and sets `resetsAt` on each usage window. In environments where IANA timezone data (e.g., ICU) is unavailable, this calculation falls back to the next local midnight instead, so `resetsAt` may be based on local time in those cases. This allows Gemini candidates to participate in `earliestReset` priority ranking and display reset countdowns in the widget.
+Gemini API quotas typically reset daily. The extension determines the reset time using the following priority:
+
+1.  **API provided reset time**: If the Google API returns a specific `resetTime` for a quota bucket, it is used directly.
+2.  **Configured timezone**: If the API doesn't provide a time, the extension calculates the next midnight based on the `resetTimezone` provider setting.
+3.  **Default (Pacific Time)**: If no setting is provided, it defaults to **midnight Pacific Time** (`America/Los_Angeles`).
+
+### Configuration
+
+You can configure the fallback timezone in your `model-selector.json`:
+
+```json
+{
+  "providerSettings": {
+    "gemini": {
+      "resetTimezone": "local"
+    }
+  }
+}
+```
+
+Options for `resetTimezone`:
+- `"local"`: Uses your machine's local midnight.
+- IANA Timezone ID: e.g., `"America/New_York"`, `"Europe/London"`, `"Asia/Tokyo"`.
+- Defaults to `"America/Los_Angeles"`.
+
+In environments where IANA timezone data (e.g., ICU) is unavailable, the calculation falls back to the next local midnight.
 
 ## Logic Details
 

--- a/src/fetchers/antigravity.ts
+++ b/src/fetchers/antigravity.ts
@@ -363,7 +363,9 @@ export async function fetchAntigravityUsage(
       },
       windows: RateWindow[] = [],
       claudeOrGptOss = getQuotaInfo([
+        "claude-sonnet-4-5",
         "claude-sonnet-4-6",
+        "claude-opus-4-5-thinking",
         "claude-opus-4-6-thinking",
         "gpt-oss-120b-medium",
       ]);
@@ -400,9 +402,7 @@ export async function fetchAntigravityUsage(
       windows.push(window);
     }
 
-    const gemini3Flash = getQuotaInfo([
-      "gemini-3-flash"
-    ]);
+    const gemini3Flash = getQuotaInfo(["gemini-3-flash"]);
     if (gemini3Flash) {
       const window: RateWindow = {
         label: "G3 Flash",

--- a/src/fetchers/antigravity.ts
+++ b/src/fetchers/antigravity.ts
@@ -363,8 +363,7 @@ export async function fetchAntigravityUsage(
       },
       windows: RateWindow[] = [],
       claudeOrGptOss = getQuotaInfo([
-        "claude-sonnet-4-5",
-        "claude-sonnet-4-5-thinking",
+        "claude-sonnet-4-6",
         "claude-opus-4-6-thinking",
         "gpt-oss-120b-medium",
       ]);
@@ -383,8 +382,8 @@ export async function fetchAntigravityUsage(
     }
 
     const gemini3Pro = getQuotaInfo([
-      "gemini-3-pro-high",
-      "gemini-3-pro-low",
+      "gemini-3.1-pro-high",
+      "gemini-3.1-pro-low",
       "gemini-3-pro-preview",
     ]);
     if (gemini3Pro) {
@@ -401,7 +400,9 @@ export async function fetchAntigravityUsage(
       windows.push(window);
     }
 
-    const gemini3Flash = getQuotaInfo(["gemini-3-flash"]);
+    const gemini3Flash = getQuotaInfo([
+      "gemini-3-flash"
+    ]);
     if (gemini3Flash) {
       const window: RateWindow = {
         label: "G3 Flash",

--- a/src/fetchers/gemini.ts
+++ b/src/fetchers/gemini.ts
@@ -461,7 +461,9 @@ export async function fetchGeminiUsage(
                   frac = bucket.remainingFraction ?? 1;
 
                 let family = "Other";
-                if (modelId.toLowerCase().includes("pro")) family = "Pro";
+                if (modelId.toLowerCase().includes("flash-lite"))
+                  family = "Flash Lite";
+                else if (modelId.toLowerCase().includes("pro")) family = "Pro";
                 else if (modelId.toLowerCase().includes("flash")) {
                   family = "Flash";
                 } else {

--- a/src/fetchers/gemini.ts
+++ b/src/fetchers/gemini.ts
@@ -13,36 +13,45 @@ import {
 } from "./common.js";
 
 /**
- * Compute the next midnight in the America/Los_Angeles (Pacific) timezone.
+ * Compute the next midnight in the specified timezone (default: America/Los_Angeles).
  * Gemini API quotas reset daily at midnight Pacific Time.
  */
-export function nextMidnightPacific(now: Date = new Date()): Date {
-  // Interpret "now" in the Pacific time zone
-  const pacificNow = DateTime.fromJSDate(now, {
-    zone: "America/Los_Angeles",
+export function nextMidnight(
+  now: Date = new Date(),
+  timezone: string = "America/Los_Angeles",
+): Date {
+  // If "local" is requested, return the next local midnight
+  if (timezone.toLowerCase() === "local") {
+    const localMidnight = new Date(now);
+    localMidnight.setHours(24, 0, 0, 0);
+    return localMidnight;
+  }
+
+  // Interpret "now" in the specified time zone
+  const zonedNow = DateTime.fromJSDate(now, {
+    zone: timezone,
   });
 
-  // If the Pacific time zone isn't available (e.g., missing ICU data),
+  // If the time zone isn't available (e.g., missing ICU data or invalid ID),
   // fall back to the next local midnight using native Date APIs.
-  if (!pacificNow.isValid) {
+  if (!zonedNow.isValid) {
     const localMidnight = new Date(now);
     // Set to the start of the next local day
     localMidnight.setHours(24, 0, 0, 0);
     return localMidnight;
   }
 
-  // Next midnight Pacific = start of the next calendar day in Pacific
-  const nextPacificMidnight = pacificNow.plus({ days: 1 }).startOf("day");
+  // Next midnight in zone = start of the next calendar day in zone
+  const nextZonedMidnight = zonedNow.plus({ days: 1 }).startOf("day");
 
   // Convert back to a UTC Date; luxon handles DST transitions correctly.
-  // If for some reason this DateTime is invalid, also fall back to next local midnight.
-  if (!nextPacificMidnight.isValid) {
+  if (!nextZonedMidnight.isValid) {
     const localMidnight = new Date(now);
     localMidnight.setHours(24, 0, 0, 0);
     return localMidnight;
   }
 
-  return nextPacificMidnight.toJSDate();
+  return nextZonedMidnight.toJSDate();
 }
 
 interface GeminiTokenInfo {
@@ -58,6 +67,7 @@ interface GeminiTokenInfo {
 export async function fetchGeminiUsage(
   modelRegistry: unknown,
   piAuth: Record<string, unknown> = {},
+  settings?: { resetTimezone?: string },
 ): Promise<UsageSnapshot[]> {
   try {
     writeDebugLog("fetchGeminiUsage: starting");
@@ -452,13 +462,18 @@ export async function fetchGeminiUsage(
                 buckets?: Array<{
                   modelId?: string;
                   remainingFraction?: number;
+                  resetTime?: string;
                 }>;
               };
-              const families: Record<string, number> = {};
+              const families: Record<
+                string,
+                { frac: number; resetTime?: string | undefined }
+              > = {};
 
               for (const bucket of dataTyped.buckets || []) {
                 const modelId = bucket.modelId || "unknown",
-                  frac = bucket.remainingFraction ?? 1;
+                  frac = bucket.remainingFraction ?? 1,
+                  resetTime = bucket.resetTime;
 
                 let family = "Other";
                 if (modelId.toLowerCase().includes("flash-lite"))
@@ -476,19 +491,30 @@ export async function fetchGeminiUsage(
 
                 if (!family) family = "Other";
 
-                const existingFamily = families[family];
-                if (existingFamily === undefined || frac < existingFamily) {
-                  families[family] = frac;
+                const existing = families[family];
+                if (existing === undefined || frac < existing.frac) {
+                  families[family] = { frac, resetTime };
                 }
               }
 
               const windows: RateWindow[] = [];
-              const resetTime = nextMidnightPacific();
-              const resetDesc = formatReset(resetTime);
-              for (const [label, frac] of Object.entries(families)) {
+              const defaultResetTime = nextMidnight(
+                new Date(),
+                settings?.resetTimezone,
+              );
+              const defaultResetDesc = formatReset(defaultResetTime);
+
+              for (const [label, info] of Object.entries(families)) {
+                const resetTime = info.resetTime
+                  ? new Date(info.resetTime)
+                  : defaultResetTime;
+                const resetDesc = info.resetTime
+                  ? formatReset(resetTime)
+                  : defaultResetDesc;
+
                 windows.push({
                   label,
-                  usedPercent: (1 - frac) * 100,
+                  usedPercent: (1 - info.frac) * 100,
                   resetsAt: resetTime,
                   resetDescription: resetDesc,
                 });

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -794,7 +794,7 @@ async function finalizeSelection(
   reason: SelectorReason,
   selfInitiatedModelChange?: { current: boolean },
 ): Promise<boolean> {
-  if (!mapping || !mapping.model) {
+  if (!mapping?.model) {
     const usage = { provider: best.provider } as {
       provider: string;
       account?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,8 +83,13 @@ export interface MinimaxSettings {
   groupId?: string;
 }
 
+export interface GeminiSettings {
+  resetTimezone?: string; // IANA timezone ID, e.g. "America/New_York", or "local"
+}
+
 export interface ProviderSettings {
   minimax?: MinimaxSettings;
+  gemini?: GeminiSettings;
 }
 
 export interface LoadedConfig {

--- a/src/usage-fetchers.ts
+++ b/src/usage-fetchers.ts
@@ -66,7 +66,8 @@ export async function fetchAllUsages(
       },
       {
         provider: "gemini",
-        fetch: () => fetchGeminiUsage(modelRegistry, piAuth),
+        fetch: () =>
+          fetchGeminiUsage(modelRegistry, piAuth, providerSettings?.gemini),
       },
       {
         provider: "codex",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -126,7 +126,7 @@ export function renderUsageWidget(ctx: ExtensionContext): void {
   if (typeof ui?.setWidget !== "function") return;
 
   const state = currentWidgetState;
-  if (!state || !state.config.widget.enabled) {
+  if (!state?.config.widget.enabled) {
     // Clear widget if disabled or no state
     ui.setWidget("model-selector", undefined);
     return;
@@ -157,7 +157,7 @@ export function renderUsageWidget(ctx: ExtensionContext): void {
         if (seenModels.has(modelKey)) continue;
         seenModels.add(modelKey);
       } else {
-        const bucketKey = `${candidate.provider}|${candidate.displayName}|${candidate.account || ""}`;
+        const bucketKey = `${candidate.provider}|${candidate.displayName}|${candidate.account || ""}|${candidate.windowLabel}`;
         if (seenBuckets.has(bucketKey)) continue;
         seenBuckets.add(bucketKey);
       }

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -596,17 +596,15 @@ async function runMappingWizard(ctx: ExtensionContext): Promise<void> {
           actionChoice === "Map by pattern"
         ) {
           // Filter models to only show those from the same provider as the usage bucket
-          const providerModels = availableModels.filter(
-            (model) => model.provider === selectedCandidate.provider,
+          let providerModels = availableModels.filter(
+            (model) =>
+              model.provider === selectedCandidate.provider ||
+              model.provider.includes(selectedCandidate.provider) ||
+              selectedCandidate.provider.includes(model.provider),
           );
 
           if (providerModels.length === 0) {
-            notify(
-              ctx,
-              "warning",
-              `No models found for provider ${selectedCandidate.provider}. Cannot map this bucket.`,
-            );
-            return;
+            providerModels = availableModels;
           }
 
           const providerModelLabels = providerModels.map(

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -427,11 +427,7 @@ async function runMappingWizard(ctx: ExtensionContext): Promise<void> {
                 const normalizedEntry = getRawMappings({
                   mappings: [entry],
                 })[0];
-                if (
-                  !normalizedEntry ||
-                  !normalizedEntry.model ||
-                  normalizedEntry.ignore
-                ) {
+                if (!normalizedEntry?.model || normalizedEntry.ignore) {
                   continue;
                 }
                 if (mappingKey(normalizedEntry) === targetKey) {
@@ -441,11 +437,7 @@ async function runMappingWizard(ctx: ExtensionContext): Promise<void> {
               }
             }
 
-            if (
-              !normalizedMatch ||
-              !normalizedMatch.model ||
-              !rawMappingToUpdate
-            ) {
+            if (!normalizedMatch?.model || !rawMappingToUpdate) {
               notify(
                 ctx,
                 "warning",

--- a/tests/anthropic.test.ts
+++ b/tests/anthropic.test.ts
@@ -285,6 +285,44 @@ describe("Anthropic Usage Fetcher", () => {
       // Both have 0.8 utilization, so it should pick the LATEST reset (the 1 hour one from five_hour)
       expect(sonnet?.resetsAt?.getTime()).toBe(now + 3600 * 1000);
     });
+
+    it("should return model-specific windows and NOT return Shared window when model-specific ones are present", async () => {
+      const mockResponse = {
+        seven_day_sonnet: {
+          utilization: 0.3,
+          resets_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        },
+        seven_day_opus: {
+          utilization: 0.6,
+          resets_at: new Date(Date.now() + 7200 * 1000).toISOString(),
+        },
+      };
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockResponse),
+        }),
+      );
+
+      const result = await fetchClaudeUsage(undefined, {
+        anthropic: { access: "fake-token" },
+      });
+
+      const labels = result.windows.map((w) => w.label);
+      expect(labels).toContain("Sonnet");
+      expect(labels).toContain("Opus");
+      expect(labels).not.toContain("Shared");
+
+      expect(
+        result.windows.find((w) => w.label === "Sonnet")?.usedPercent,
+      ).toBe(60);
+      expect(result.windows.find((w) => w.label === "Opus")?.usedPercent).toBe(
+        60,
+      );
+    });
   });
 
   describe("Error Handling", () => {

--- a/tests/gemini.test.ts
+++ b/tests/gemini.test.ts
@@ -51,6 +51,7 @@ describe("Gemini Usage Fetcher", () => {
             buckets: [
               { modelId: "gemini-2.5-pro", remainingFraction: 0.8 },
               { modelId: "gemini-2.0-flash", remainingFraction: 0.5 },
+              { modelId: "gemini-2.0-flash-lite", remainingFraction: 0.7 },
             ],
           }),
       }),
@@ -74,7 +75,11 @@ describe("Gemini Usage Fetcher", () => {
     const snapshot = snapshots.find((s) => s.account === "test-project");
     expect(snapshot).toBeDefined();
     expect(snapshot!.error).toBeUndefined();
-    expect(snapshot!.windows.length).toBe(2);
+    expect(snapshot!.windows.length).toBe(3);
+
+    const flashLite = snapshot!.windows.find((w) => w.label === "Flash Lite");
+    expect(flashLite).toBeDefined();
+    expect(flashLite!.usedPercent).toBeCloseTo(30); // 1 - 0.7
 
     for (const w of snapshot!.windows) {
       expect(w.resetsAt).toBeInstanceOf(Date);

--- a/tests/gemini.test.ts
+++ b/tests/gemini.test.ts
@@ -1,13 +1,73 @@
 import { DateTime } from "luxon";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchGeminiUsage,
-  nextMidnightPacific,
-} from "../src/fetchers/gemini.js";
+import { fetchGeminiUsage, nextMidnight } from "../src/fetchers/gemini.js";
 
 describe("Gemini Usage Fetcher", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("should respect resetTimezone setting", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            buckets: [{ modelId: "gemini-pro", remainingFraction: 1 }],
+          }),
+      }),
+    );
+
+    const modelRegistry = {
+      authStorage: {
+        get: () => ({ accessToken: "tok", projectId: "pid" }),
+      },
+    };
+
+    // Use UTC for predictable test result
+    const snapshots = await fetchGeminiUsage(
+      modelRegistry,
+      {},
+      {
+        resetTimezone: "UTC",
+      },
+    );
+    const resetTime = snapshots[0]!.windows[0]!.resetsAt!;
+
+    // In UTC, next midnight should be at 00:00:00 UTC
+    expect(resetTime.getUTCHours()).toBe(0);
+    expect(resetTime.getUTCMinutes()).toBe(0);
+  });
+
+  it("should respect resetTime from API response if present", async () => {
+    const mockResetTime = new Date(Date.now() + 5 * 3600 * 1000).toISOString();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            buckets: [
+              {
+                modelId: "gemini-pro",
+                remainingFraction: 0.5,
+                resetTime: mockResetTime,
+              },
+            ],
+          }),
+      }),
+    );
+
+    const modelRegistry = {
+      authStorage: {
+        get: () => ({ accessToken: "tok", projectId: "pid" }),
+      },
+    };
+
+    const snapshots = await fetchGeminiUsage(modelRegistry, {});
+    const window = snapshots[0]!.windows[0]!;
+    expect(window.resetsAt?.toISOString()).toBe(mockResetTime);
   });
 
   it("should handle expiresAt: 0 correctly in merging", async () => {
@@ -153,15 +213,15 @@ function hasPacificTimeZoneSupport(): boolean {
   }
 }
 
-describe("nextMidnightPacific", () => {
+describe("nextMidnight", () => {
   it("returns a Date in the future", () => {
-    const result = nextMidnightPacific();
+    const result = nextMidnight();
     expect(result).toBeInstanceOf(Date);
     expect(result.getTime()).toBeGreaterThan(Date.now());
   });
 
   it("returns a time at most ~24h in the future", () => {
-    const result = nextMidnightPacific();
+    const result = nextMidnight();
     const diffMs = result.getTime() - Date.now();
     // Should be within 25 hours (to account for DST fall-back) + small tolerance
     expect(diffMs).toBeLessThanOrEqual(25 * 60 * 60 * 1000 + 5000);
@@ -173,7 +233,7 @@ describe("nextMidnightPacific", () => {
     () => {
       // 2025-06-15 10:00:00 UTC = 2025-06-15 03:00:00 PDT
       const now = new Date("2025-06-15T10:00:00Z");
-      const result = nextMidnightPacific(now);
+      const result = nextMidnight(now, "America/Los_Angeles");
       expect(result).toBeInstanceOf(Date);
       // Next midnight Pacific is 2025-06-16 00:00:00 PDT = 2025-06-16 07:00:00 UTC
       expect(result.getTime()).toBeGreaterThan(now.getTime());
@@ -194,7 +254,7 @@ describe("nextMidnightPacific", () => {
       it("handles PST (winter) correctly", () => {
         // 2025-01-15 10:00:00 UTC = 2025-01-15 02:00:00 PST (UTC-8)
         const now = new Date("2025-01-15T10:00:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight PST = 2025-01-16 00:00:00 PST = 2025-01-16 08:00:00 UTC
         const expected = new Date("2025-01-16T08:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -203,7 +263,7 @@ describe("nextMidnightPacific", () => {
       it("handles PDT (summer) correctly", () => {
         // 2025-07-15 10:00:00 UTC = 2025-07-15 03:00:00 PDT (UTC-7)
         const now = new Date("2025-07-15T10:00:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight PDT = 2025-07-16 00:00:00 PDT = 2025-07-16 07:00:00 UTC
         const expected = new Date("2025-07-16T07:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -212,7 +272,7 @@ describe("nextMidnightPacific", () => {
       it("handles just before midnight Pacific", () => {
         // 2025-06-15 06:59:00 UTC = 2025-06-14 23:59:00 PDT
         const now = new Date("2025-06-15T06:59:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight PDT = 2025-06-15 00:00:00 PDT = 2025-06-15 07:00:00 UTC
         const expected = new Date("2025-06-15T07:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -221,7 +281,7 @@ describe("nextMidnightPacific", () => {
       it("handles just after midnight Pacific", () => {
         // 2025-06-15 07:01:00 UTC = 2025-06-15 00:01:00 PDT
         const now = new Date("2025-06-15T07:01:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight PDT = 2025-06-16 00:00:00 PDT = 2025-06-16 07:00:00 UTC
         const expected = new Date("2025-06-16T07:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -231,7 +291,7 @@ describe("nextMidnightPacific", () => {
         // 2025-03-09 09:30:00 UTC = 2025-03-09 01:30:00 PST (before spring forward at 2:00 AM)
         // At 2:00 AM, clocks jump to 3:00 AM PDT
         const now = new Date("2025-03-09T09:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-03-10 00:00:00 PDT = 2025-03-10 07:00:00 UTC
         const expected = new Date("2025-03-10T07:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -240,7 +300,7 @@ describe("nextMidnightPacific", () => {
       it("handles spring-forward DST transition (after the gap)", () => {
         // 2025-03-09 10:30:00 UTC = 2025-03-09 03:30:00 PDT (after spring forward)
         const now = new Date("2025-03-09T10:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-03-10 00:00:00 PDT = 2025-03-10 07:00:00 UTC
         const expected = new Date("2025-03-10T07:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -250,7 +310,7 @@ describe("nextMidnightPacific", () => {
         // 2025-11-02 07:30:00 UTC = 2025-11-02 00:30:00 PDT (before fall back at 2:00 AM)
         // At 2:00 AM PDT, clocks fall back to 1:00 AM PST
         const now = new Date("2025-11-02T07:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-11-03 00:00:00 PST = 2025-11-03 08:00:00 UTC
         const expected = new Date("2025-11-03T08:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -259,7 +319,7 @@ describe("nextMidnightPacific", () => {
       it("handles fall-back DST transition (after the repeat hour)", () => {
         // 2025-11-02 10:30:00 UTC = 2025-11-02 02:30:00 PST (after fall back)
         const now = new Date("2025-11-02T10:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-11-03 00:00:00 PST = 2025-11-03 08:00:00 UTC
         const expected = new Date("2025-11-03T08:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -268,7 +328,7 @@ describe("nextMidnightPacific", () => {
       it("handles first occurrence of repeated hour during fall-back", () => {
         // 2025-11-02 08:30:00 UTC = 2025-11-02 01:30:00 PDT (first 1:30 AM, PDT)
         const now = new Date("2025-11-02T08:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-11-03 00:00:00 PST = 2025-11-03 08:00:00 UTC
         const expected = new Date("2025-11-03T08:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -277,7 +337,7 @@ describe("nextMidnightPacific", () => {
       it("handles second occurrence of repeated hour during fall-back", () => {
         // 2025-11-02 09:30:00 UTC = 2025-11-02 01:30:00 PST (second 1:30 AM, PST)
         const now = new Date("2025-11-02T09:30:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Next midnight is 2025-11-03 00:00:00 PST = 2025-11-03 08:00:00 UTC
         const expected = new Date("2025-11-03T08:00:00Z");
         expect(result.getTime()).toBe(expected.getTime());
@@ -287,7 +347,7 @@ describe("nextMidnightPacific", () => {
 
   describe("fallback behavior (no timezone support)", () => {
     it("returns next local midnight when Pacific timezone is unavailable", () => {
-      // Explicitly mock/stub the timezone/Luxon path so pacificNow.isValid becomes false.
+      // Explicitly mock/stub the timezone/Luxon path so zonedNow.isValid becomes false.
       const fromJSDateSpy = vi
         .spyOn(DateTime, "fromJSDate")
         .mockReturnValue({ isValid: false } as any);
@@ -296,7 +356,7 @@ describe("nextMidnightPacific", () => {
         // This test validates the fallback behavior when IANA timezone data is missing.
         // The fallback returns the next local midnight, which is a reasonable default.
         const now = new Date("2025-06-15T10:00:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Should return a Date in the future
         expect(result.getTime()).toBeGreaterThan(now.getTime());
         // Should be at most ~24 hours later (plus tolerance for DST)
@@ -319,7 +379,7 @@ describe("nextMidnightPacific", () => {
 
       try {
         const now = new Date("2025-06-15T23:59:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Should return midnight of the next day (local timezone)
         const expectedLocalMidnight = new Date(now);
         expectedLocalMidnight.setHours(24, 0, 0, 0);
@@ -336,7 +396,7 @@ describe("nextMidnightPacific", () => {
 
       try {
         const now = new Date("2025-06-15T00:01:00Z");
-        const result = nextMidnightPacific(now);
+        const result = nextMidnight(now, "America/Los_Angeles");
         // Should return midnight of the next day (local timezone)
         const expectedLocalMidnight = new Date(now);
         expectedLocalMidnight.setHours(24, 0, 0, 0);
@@ -344,6 +404,17 @@ describe("nextMidnightPacific", () => {
       } finally {
         fromJSDateSpy.mockRestore();
       }
+    });
+  });
+
+  describe("local midnight behavior", () => {
+    it("returns next local midnight when 'local' is specified", () => {
+      const now = new Date("2025-06-15T10:00:00Z");
+      const result = nextMidnight(now, "local");
+
+      const expectedLocalMidnight = new Date(now);
+      expectedLocalMidnight.setHours(24, 0, 0, 0);
+      expect(result.getTime()).toBe(expectedLocalMidnight.getTime());
     });
   });
 });

--- a/tests/usage-fetchers.test.ts
+++ b/tests/usage-fetchers.test.ts
@@ -498,8 +498,8 @@ describe("Usage Fetchers", () => {
               "claude-opus-4-6-thinking": {
                 quotaInfo: { remainingFraction: 0.3 },
               },
-              "gemini-3-pro-low": { quotaInfo: { remainingFraction: 0.1 } },
-              "gemini-3-pro-high": { quotaInfo: { remainingFraction: 0.2 } },
+              "gemini-3.1-pro-low": { quotaInfo: { remainingFraction: 0.1 } },
+              "gemini-3.1-pro-high": { quotaInfo: { remainingFraction: 0.2 } },
               "gemini-3-flash": { quotaInfo: { remainingFraction: 0.9 } },
             },
           }),
@@ -590,13 +590,13 @@ describe("Usage Fetchers", () => {
           ok: true,
           json: async () => ({
             models: {
-              "gemini-3-pro-high": {
+              "gemini-3.1-pro-high": {
                 quotaInfo: {
                   remainingFraction: 0.2,
                   resetTime: "2024-03-01T00:00:00Z",
                 },
               },
-              "gemini-3-pro-low": {
+              "gemini-3.1-pro-low": {
                 quotaInfo: {
                   remainingFraction: 0.1,
                   resetTime: "2024-04-01T00:00:00Z",

--- a/tests/widget.test.ts
+++ b/tests/widget.test.ts
@@ -330,6 +330,44 @@ describe("Widget", () => {
       );
     });
 
+    it("should show different unmapped windows for the same provider if they have different labels", () => {
+      const setWidgetMock = vi.fn();
+      const mockCtx = {
+        hasUI: true,
+        ui: { setWidget: setWidgetMock },
+      } as unknown as ExtensionContext;
+      const config = {
+        mappings: [], // No mappings, all unmapped
+        widget: { enabled: true, showCount: 5, placement: "belowEditor" },
+      } as unknown as LoadedConfig;
+      const candidates = [
+        {
+          provider: "gemini",
+          displayName: "Gemini",
+          windowLabel: "Pro",
+          usedPercent: 0,
+          remainingPercent: 100,
+          account: "project-1",
+        },
+        {
+          provider: "gemini",
+          displayName: "Gemini",
+          windowLabel: "Flash",
+          usedPercent: 0,
+          remainingPercent: 100,
+          account: "project-1",
+        },
+      ] as unknown as UsageCandidate[];
+      updateWidgetState({ candidates, config });
+      renderUsageWidget(mockCtx);
+      const renderFn = setWidgetMock.mock.calls![0]![1]!;
+      const widget = renderFn(null, theme);
+      const output = widget.render(500);
+      expect(output[1]).toContain("Gemini");
+      expect(output[1]).toContain("Pro");
+      expect(output[1]).toContain("Flash");
+    });
+
     it("should not show LOCK OFF entry when enableModelLocking is true", () => {
       const setWidgetMock = vi.fn();
       const mockCtx = {


### PR DESCRIPTION
This PR introduces several improvements to model quota tracking and display, specifically for Anthropic and Gemini providers.

Key Changes:

- New Model Windows: Added support for tracking specific quota windows for Sonnet and Opus (Anthropic) and Flash Lite (Gemini).

- Accurate Gemini Resets: Updated the Gemini fetcher to respect the resetTime field provided by the API. This ensures that models with non-uniform reset times (like those in the Gemini CLI) are displayed accurately.

- Configurable Timezone: Added a new resetTimezone setting under providerSettings.gemini. Users can now set this to "local" or any IANA timezone ID to customize the fallback reset
 calculation.

- Widget Improvements: Updated candidate deduplication in the widget to ensure distinct unmapped quotas from the same account (e.g., Gemini Pro vs. Flash) are all displayed.

- Flexible Wizard Mapping: Loosened the provider ID filter in the configuration wizard to allow easier mapping (e.g., matching antigravity usage to google-antigravity models).

- Documentation & Tests: Updated the README, Gemini documentation, and example config. Expanded test suites to cover the new window logic and timezone settings.

Verification:

- Ran full test suite (npm test): All 539 tests passed.
- Verified linting and type-checking: Passed.
- Tested widget display with multiple Gemini buckets.