### PR TITLE
Vendor and harden the TypeScript security ruleset with snapshot tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "luxon": "^3.7.2"
       },
       "devDependencies": {
+        "@ast-grep/cli": "^0.45.1",
         "@biomejs/biome": "2.5.3",
         "@mariozechner/pi-coding-agent": "0.73.1",
         "@types/luxon": "3.7.4",
@@ -62,6 +63,158 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.45.1.tgz",
+      "integrity": "sha512-Bt9Vuqd+gmtwERy1kzj5R9yq96Ws1d2ZukEXy0mzLcJ+S0pU9uaJhETUSTmaHro1LNu9G4GeJ3YOXL1gQRQySA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.45.1",
+        "@ast-grep/cli-darwin-x64": "0.45.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.45.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.45.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.45.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.45.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.45.1"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.45.1.tgz",
+      "integrity": "sha512-hN/TDTvfry106SWn0pxepxFpAOvibuZJ80J5xU80WmY97Vjdc0cSKd49GBz2F+V8bzqn0SXchnoPXKLSJHB9kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.45.1.tgz",
+      "integrity": "sha512-wyQ8hXqNwTC6+4KYf4LvmemNyq+iKXfimXVKS9ZDJ8mE7/3VOuynPVuCFB7h+C5rVErzDJ9tZWwLLpSLnpYuhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.45.1.tgz",
+      "integrity": "sha512-yhIGIXDcvI7v4hLicA1dtvkf+QJ8WA8f/b/066gVhqhimiBgbdONkavrE3P5iOjwMLhfyTF0cQV9rkiKg93fvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.45.1.tgz",
+      "integrity": "sha512-vL6zdHagU3znogJN5KuZWECdTw9dTUf6/e5G5k9bNpvI+0gcrfuJj8hH8o/Wqyb5Qd4tuNdgJMwbHDTFbhtYvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.45.1.tgz",
+      "integrity": "sha512-JzOFnMAk+Wd6ApnP96Fam7eJX5JiV5/V09akzc/p129Ko1tmym7w/1oALuyVMV+unRTepj9XRrtfrF3XZG64lQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.45.1.tgz",
+      "integrity": "sha512-uwgCUOq6B8//u+LhicTjg3CfA9mcpCgajfv5AWNxHE1Qw8F2wLRszDXK03+l/l8biaE13uHE2857mr6x6m/F+A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.45.1.tgz",
+      "integrity": "sha512-fDYXALDte7yt44Jmhu7kjPZFCmHOPN6SrtMAYqKlYgkxPtSC/UfTe2XpDNxyTgBV3rMLkw/61bj6KQkwXwuBNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3544,6 +3697,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     }
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.45.1",
     "@biomejs/biome": "2.5.3",
     "@mariozechner/pi-coding-agent": "0.73.1",
     "@types/luxon": "3.7.4",

--- a/rules/ESSENTIALS-LICENSE.txt
+++ b/rules/ESSENTIALS-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rules/typescript/security/detect-angular-sce-disabled-typescript.yml
+++ b/rules/typescript/security/detect-angular-sce-disabled-typescript.yml
@@ -1,0 +1,38 @@
+id: detect-angular-sce-disabled-typescript
+language: typescript
+severity: warning
+message: >-
+  $sceProvider is set to false. Disabling Strict Contextual escaping
+  (SCE) in an AngularJS application could provide additional attack surface
+  for XSS vulnerabilities.
+note: >-
+  [CWE-79] Improper Neutralization of Input During Web Page Generation.
+  [REFERENCES]
+      - https://docs.angularjs.org/api/ng/service/$sce
+      - https://owasp.org/www-chapter-london/assets/slides/OWASPLondon20170727_AngularJS.pdf
+ast-grep-essentials: true
+rule:
+  kind: expression_statement
+  regex: ^\$sceProvider
+  has:
+    kind: call_expression
+    stopBy: end
+    all:
+      - has:
+          kind: member_expression
+          nthChild: 1
+          all:
+            - has:
+                kind: identifier
+                regex: ^\$sceProvider$
+            - has:
+                kind: property_identifier
+                regex: ^enabled$
+          precedes:
+            kind: arguments
+            has:
+              kind: "false"
+              nthChild: 1
+            not:
+              has:
+                nthChild: 2

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -1,0 +1,207 @@
+id: express-session-hardcoded-secret-typescript
+language: typescript
+severity: warning
+message: >-
+  A hard-coded credential was detected. It is not recommended to store
+  credentials in source-code, as this risks secrets being leaked and used by
+  either an internal or external malicious adversary. It is recommended to
+  use environment variables to securely provide credentials or retrieve
+  credentials from a secure vault or HSM (Hardware Security Module).
+note: >-
+  [CWE-798] Use of Hard-coded Credentials.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+ast-grep-essentials: true
+rule:
+  kind: pair
+  all:
+    - has:
+        kind: property_identifier
+        regex: ^secret$
+        nthChild: 1
+    - has:
+        kind: string
+        nthChild: 2
+  inside:
+    stopBy: end
+    kind: object
+    pattern: $OBJECT
+    any:
+      - inside:
+          stopBy: end
+          kind: call_expression
+          pattern: $APP.use($SESSION($OBJECT))
+          inside:
+            stopBy: end
+            follows:
+              stopBy: end
+              any:
+                - kind: import_statement
+                  all:
+                    - has:
+                        kind: import_clause
+                        any:
+                          - has:
+                              kind: namespace_import
+                              has:
+                                kind: identifier
+                                pattern: $SESSION
+                          - has:
+                              kind: named_imports
+                              has:
+                                kind: import_specifier
+                                pattern: $SESSION
+                          - has:
+                              kind: identifier
+                              pattern: $SESSION
+                    - has:
+                        kind: string
+                        nthChild: 2
+                        regex: ^'express-session'$
+                - any:
+                    - kind: lexical_declaration
+                      all:
+                        - has:
+                            kind: variable_declarator
+                            all:
+                              - has:
+                                  kind: identifier
+                                  pattern: $SESSION
+                                  nthChild: 1
+                              - has:
+                                  kind: call_expression
+                                  nthChild: 2
+                                  regex: ^require\('express-session'\)$
+                    - kind: expression_statement
+                      has:
+                        kind: assignment_expression
+                        all:
+                          - has:
+                              kind: identifier
+                              pattern: $SESSION
+                              nthChild: 1
+                          - has:
+                              kind: call_expression
+                              nthChild: 2
+                              regex: ^require\('express-session'\)$
+
+      - inside:
+          stopBy: end
+
+          any:
+            - kind: lexical_declaration
+            - any:
+                - kind: expression_statement
+                - kind: assignment_expression
+              not:
+                follows:
+                  kind: ERROR
+            - kind: variable_declaration
+          has:
+            stopBy: end
+            any:
+              - kind: variable_declarator
+              - kind: assignment_expression
+            has:
+              kind: identifier
+              pattern: $IDENTIFIER
+              any:
+                - precedes:
+                    stopBy: end
+                    kind: object
+                    pattern: $OBJECT
+                - precedes:
+                    stopBy: end
+                    has:
+                      stopBy: end
+                      kind: object
+                      pattern: $OBJECT
+                - inside:
+                    stopBy: end
+                    precedes:
+                      stopBy: end
+                      has:
+                        stopBy: end
+                        kind: object
+                        pattern: $OBJECT
+          precedes:
+            stopBy: end
+            has:
+              stopBy: end
+              kind: call_expression
+              pattern: $APP.use($SESSION($IDENTIFIER))
+              has:
+                stopBy: end
+                kind: identifier
+                pattern: $IDENTIFIER
+              inside:
+                stopBy: end
+                follows:
+                  stopBy: end
+                  any:
+                    - kind: import_statement
+                      all:
+                        - has:
+                            kind: import_clause
+                            any:
+                              - has:
+                                  kind: namespace_import
+                                  has:
+                                    kind: identifier
+                                    pattern: $SESSION
+                              - has:
+                                  kind: named_imports
+                                  has:
+                                    kind: import_specifier
+                                    pattern: $SESSION
+                              - has:
+                                  kind: identifier
+                                  pattern: $SESSION
+                        - has:
+                            kind: string
+                            nthChild: 2
+                            regex: ^'express-session'$
+                    - any:
+                        - any:
+                            - kind: lexical_declaration
+                            - kind: variable_declaration
+                          all:
+                            - has:
+                                kind: variable_declarator
+                                all:
+                                  - has:
+                                      kind: identifier
+                                      pattern: $SESSION
+                                      nthChild: 1
+                                  - has:
+                                      kind: call_expression
+                                      nthChild: 2
+                                      all:
+                                        - has:
+                                            nthChild: 1
+                                            kind: identifier
+                                            regex: ^require$
+                                        - has:
+                                            nthChild: 2
+                                            kind: arguments
+                                            regex: ^\('express-session'\)$
+                        - kind: expression_statement
+                          has:
+                            kind: assignment_expression
+                            all:
+                              - has:
+                                  kind: identifier
+                                  pattern: $SESSION
+                                  nthChild: 1
+                              - has:
+                                  kind: call_expression
+                                  nthChild: 2
+                                  all:
+                                    - has:
+                                        nthChild: 1
+                                        kind: identifier
+                                        regex: ^require$
+                                    - has:
+                                        nthChild: 2
+                                        kind: arguments
+                                        regex: ^\('express-session'\)$

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -57,7 +57,9 @@ rule:
                     - has:
                         kind: string
                         nthChild: 2
-                        regex: ^'express-session'$
+                        has:
+                          kind: string_fragment
+                          regex: ^express-session$
                 - any:
                     - kind: lexical_declaration
                       all:
@@ -71,7 +73,20 @@ rule:
                               - has:
                                   kind: call_expression
                                   nthChild: 2
-                                  regex: ^require\('express-session'\)$
+                                  all:
+                                    - has:
+                                        nthChild: 1
+                                        kind: identifier
+                                        regex: ^require$
+                                    - has:
+                                        nthChild: 2
+                                        kind: arguments
+                                        has:
+                                          stopBy: end
+                                          kind: string
+                                          has:
+                                            kind: string_fragment
+                                            regex: ^express-session$
                     - kind: expression_statement
                       has:
                         kind: assignment_expression
@@ -83,7 +98,20 @@ rule:
                           - has:
                               kind: call_expression
                               nthChild: 2
-                              regex: ^require\('express-session'\)$
+                              all:
+                                - has:
+                                    nthChild: 1
+                                    kind: identifier
+                                    regex: ^require$
+                                - has:
+                                    nthChild: 2
+                                    kind: arguments
+                                    has:
+                                      stopBy: end
+                                      kind: string
+                                      has:
+                                        kind: string_fragment
+                                        regex: ^express-session$
 
       - inside:
           stopBy: end
@@ -160,7 +188,9 @@ rule:
                         - has:
                             kind: string
                             nthChild: 2
-                            regex: ^'express-session'$
+                            has:
+                              kind: string_fragment
+                              regex: ^express-session$
                     - any:
                         - any:
                             - kind: lexical_declaration
@@ -184,7 +214,12 @@ rule:
                                         - has:
                                             nthChild: 2
                                             kind: arguments
-                                            regex: ^\('express-session'\)$
+                                            has:
+                                              stopBy: end
+                                              kind: string
+                                              has:
+                                                kind: string_fragment
+                                                regex: ^express-session$
                         - kind: expression_statement
                           has:
                             kind: assignment_expression
@@ -204,4 +239,9 @@ rule:
                                     - has:
                                         nthChild: 2
                                         kind: arguments
-                                        regex: ^\('express-session'\)$
+                                        has:
+                                          stopBy: end
+                                          kind: string
+                                          has:
+                                            kind: string_fragment
+                                            regex: ^express-session$

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -19,9 +19,16 @@ rule:
         kind: property_identifier
         regex: ^secret$
         nthChild: 1
-    - has:
-        kind: string
-        nthChild: 2
+    - any:
+        - has:
+            kind: string
+            nthChild: 2
+        - has:
+            kind: template_string
+            nthChild: 2
+            not:
+              has:
+                kind: template_substitution
   inside:
     stopBy: end
     kind: object
@@ -61,7 +68,9 @@ rule:
                           kind: string_fragment
                           regex: ^express-session$
                 - any:
-                    - kind: lexical_declaration
+                    - any:
+                        - kind: lexical_declaration
+                        - kind: variable_declaration
                       all:
                         - has:
                             kind: variable_declarator

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -117,6 +117,7 @@ rule:
                                         has:
                                           stopBy: end
                                           kind: string
+                                          nthChild: 1
                                           has:
                                             kind: string_fragment
                                             regex: ^express-session$
@@ -142,6 +143,7 @@ rule:
                                     has:
                                       stopBy: end
                                       kind: string
+                                      nthChild: 1
                                       has:
                                         kind: string_fragment
                                         regex: ^express-session$
@@ -250,6 +252,7 @@ rule:
                                             has:
                                               stopBy: end
                                               kind: string
+                                              nthChild: 1
                                               has:
                                                 kind: string_fragment
                                                 regex: ^express-session$
@@ -275,6 +278,7 @@ rule:
                                         has:
                                           stopBy: end
                                           kind: string
+                                          nthChild: 1
                                           has:
                                             kind: string_fragment
                                             regex: ^express-session$

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -15,10 +15,19 @@ ast-grep-essentials: true
 rule:
   kind: pair
   all:
-    - has:
-        kind: property_identifier
-        regex: ^secret$
-        nthChild: 1
+    - any:
+        - has:
+            kind: property_identifier
+            regex: ^secret$
+            nthChild: 1
+        # Quoted object keys carry the same credential, so match the string
+        # fragment quote-agnostically.
+        - has:
+            kind: string
+            nthChild: 1
+            has:
+              kind: string_fragment
+              regex: ^secret$
     - any:
         - has:
             kind: string

--- a/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
+++ b/rules/typescript/security/express-session-hardcoded-secret-typescript.yml
@@ -29,6 +29,21 @@ rule:
             not:
               has:
                 kind: template_substitution
+        # express-session accepts an array of secrets for rotation, so an
+        # array containing any constant secret is just as much a credential
+        # as a single string; requiring at least one constant element also
+        # keeps env-only and empty arrays out.
+        - has:
+            kind: array
+            nthChild: 2
+            has:
+              any:
+                - kind: string
+                - all:
+                    - kind: template_string
+                    - not:
+                        has:
+                          kind: template_substitution
   inside:
     stopBy: end
     kind: object

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -1,0 +1,116 @@
+id: jwt-simple-noverify-typescript
+language: TypeScript
+severity: warning
+message: >-
+  "Detected the decoding of a JWT token without a verify step. JWT tokens
+      must be verified before use, otherwise the token's integrity is unknown.
+      This means a malicious actor could forge a JWT token with any claims. Set
+      'verify' to `true` before using the token."
+note: >-
+  [CWE-287] Improper Authentication
+  [CWE-345] Insufficient Verification of Data Authenticity
+  [CWE-347] Improper Verification of Cryptographic Signature
+  [REFERENCES]
+      - https://www.npmjs.com/package/jwt-simple
+      - https://cwe.mitre.org/data/definitions/287
+      - https://cwe.mitre.org/data/definitions/345
+      - https://cwe.mitre.org/data/definitions/347
+ast-grep-essentials: true
+rule:
+  pattern: $JWT.decode($TOKEN, $SECRET, $NOVERIFY $$$)
+  inside:
+    stopBy: end
+    follows:
+      stopBy: end
+      any:
+        - any:
+            - kind: lexical_declaration
+            - kind: variable_declaration
+          all:
+            - has:
+                kind: variable_declarator
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $JWT
+                      nthChild: 1
+                  - has:
+                      kind: call_expression
+                      nthChild: 2
+                      all:
+                        - has:
+                            nthChild: 1
+                            kind: identifier
+                            regex: ^require$
+                        - has:
+                            nthChild: 2
+                            kind: arguments
+                            has:
+                              stopBy: end
+                              kind: string
+                              nthChild: 1
+                              has:
+                                kind: string_fragment
+                                regex: ^jwt-simple$
+                            all:
+                              - not:
+                                  has:
+                                    nthChild: 2
+                              - not:
+                                  has:
+                                    stopBy: end
+                                    any:
+                                      - kind: object
+                                      - kind: array
+                                      - kind: pair
+
+        - kind: expression_statement
+          has:
+            kind: assignment_expression
+            all:
+              - has:
+                  kind: identifier
+                  pattern: $JWT
+                  nthChild: 1
+              - has:
+                  kind: call_expression
+                  nthChild: 2
+                  all:
+                    - has:
+                        nthChild: 1
+                        kind: identifier
+                        regex: ^require$
+                    - has:
+                        nthChild: 2
+                        kind: arguments
+                        has:
+                          stopBy: end
+                          kind: string
+                          has:
+                            kind: string_fragment
+                            regex: ^jwt-simple$
+
+constraints:
+  NOVERIFY:
+    all:
+      - any:
+          - any:
+              - regex: ^true$
+              - kind: string
+              - kind: template_string
+          - has:
+              stopBy: end
+              any:
+                - regex: ^true$
+                - kind: string
+                - kind: template_string
+              not:
+                any:
+                  - kind: property_identifier
+                  - kind: shorthand_property_identifier
+                  - any:
+                      - kind: string
+                      - kind: template_string
+                    nthChild: 1
+                inside:
+                  kind: pair

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -154,8 +154,9 @@ rule:
                                         - kind: pair
 
     # Named-import form: import { decode } from "jwt-simple" followed by a
-    # bare decode(token, secret, noVerify) call.
-    - pattern: decode($TOKEN, $SECRET, $NOVERIFY $$$)
+    # bare decode(token, secret, noVerify) call. The local name binds to
+    # $CALLEE so an aliased import like { decode as jwtDecode } matches too.
+    - pattern: $CALLEE($TOKEN, $SECRET, $NOVERIFY $$$)
       inside:
         stopBy: end
         follows:
@@ -168,9 +169,14 @@ rule:
                   kind: named_imports
                   has:
                     kind: import_specifier
-                    has:
-                      kind: identifier
-                      regex: ^decode$
+                    all:
+                      - has:
+                          kind: identifier
+                          nthChild: 1
+                          regex: ^decode$
+                      - has:
+                          kind: identifier
+                          pattern: $CALLEE
             - has:
                 kind: string
                 nthChild: 2
@@ -208,6 +214,7 @@ constraints:
               - regex: ^(?:[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$
           - all:
               - kind: unary_expression
+              - regex: ^[+-]
               - has:
                   kind: number
                   regex: ^(?:[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -17,19 +17,107 @@ note: >-
       - https://cwe.mitre.org/data/definitions/345
       - https://cwe.mitre.org/data/definitions/347
 ast-grep-essentials: true
+# The require arguments must hold the module name as the first and only
+# string argument, so require("other", "jwt-simple") cannot satisfy it.
 rule:
-  pattern: $JWT.decode($TOKEN, $SECRET, $NOVERIFY $$$)
-  inside:
-    stopBy: end
-    follows:
-      stopBy: end
-      any:
-        - any:
-            - kind: lexical_declaration
-            - kind: variable_declaration
-          all:
-            - has:
-                kind: variable_declarator
+  any:
+    # Receiver form: jwt.decode(token, secret, noVerify).
+    - pattern: $JWT.decode($TOKEN, $SECRET, $NOVERIFY $$$)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          any:
+            # const/let/var binding of the required module.
+            - any:
+                - kind: lexical_declaration
+                - kind: variable_declaration
+              all:
+                - has:
+                    kind: variable_declarator
+                    all:
+                      - has:
+                          kind: identifier
+                          pattern: $JWT
+                          nthChild: 1
+                      - has:
+                          kind: call_expression
+                          nthChild: 2
+                          all:
+                            - has:
+                                nthChild: 1
+                                kind: identifier
+                                regex: ^require$
+                            - has:
+                                nthChild: 2
+                                kind: arguments
+                                has:
+                                  stopBy: end
+                                  kind: string
+                                  nthChild: 1
+                                  has:
+                                    kind: string_fragment
+                                    regex: ^jwt-simple$
+                                  all:
+                                    - not:
+                                        has:
+                                          nthChild: 2
+                                    - not:
+                                        has:
+                                          stopBy: end
+                                          any:
+                                            - kind: object
+                                            - kind: array
+                                            - kind: pair
+
+            # ES module import of jwt-simple.
+            - kind: import_statement
+              all:
+                - has:
+                    kind: import_clause
+                    any:
+                      - has:
+                          kind: namespace_import
+                          has:
+                            kind: identifier
+                            pattern: $JWT
+                      - has:
+                          kind: named_imports
+                          has:
+                            kind: import_specifier
+                            pattern: $JWT
+                      - has:
+                          kind: identifier
+                          pattern: $JWT
+                - has:
+                    kind: string
+                    nthChild: 2
+                    has:
+                      kind: string_fragment
+                      regex: ^jwt-simple$
+
+            # TypeScript import-equals binding of the CommonJS module. The
+            # clause lives inside the import statement (the follows-visible
+            # sibling), and its require accepts exactly one string argument,
+            # so no arity guards are needed here.
+            - kind: import_statement
+              has:
+                kind: import_require_clause
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $JWT
+                  - has:
+                      stopBy: end
+                      kind: string
+                      has:
+                        kind: string_fragment
+                        regex: ^jwt-simple$
+
+            # Assignment binding of the required module.
+            - kind: expression_statement
+              has:
+                kind: assignment_expression
                 all:
                   - has:
                       kind: identifier
@@ -53,37 +141,36 @@ rule:
                               has:
                                 kind: string_fragment
                                 regex: ^jwt-simple$
-                            all:
-                              - not:
-                                  has:
-                                    nthChild: 2
-                              - not:
-                                  has:
-                                    stopBy: end
-                                    any:
-                                      - kind: object
-                                      - kind: array
-                                      - kind: pair
+                              all:
+                                - not:
+                                    has:
+                                      nthChild: 2
+                                - not:
+                                    has:
+                                      stopBy: end
+                                      any:
+                                        - kind: object
+                                        - kind: array
+                                        - kind: pair
 
-        # ES module import of jwt-simple.
-        - kind: import_statement
+    # Named-import form: import { decode } from "jwt-simple" followed by a
+    # bare decode(token, secret, noVerify) call.
+    - pattern: decode($TOKEN, $SECRET, $NOVERIFY $$$)
+      inside:
+        stopBy: end
+        follows:
+          stopBy: end
+          kind: import_statement
           all:
             - has:
                 kind: import_clause
-                any:
-                  - has:
-                      kind: namespace_import
-                      has:
-                        kind: identifier
-                        pattern: $JWT
-                  - has:
-                      kind: named_imports
-                      has:
-                        kind: import_specifier
-                        pattern: $JWT
-                  - has:
+                has:
+                  kind: named_imports
+                  has:
+                    kind: import_specifier
+                    has:
                       kind: identifier
-                      pattern: $JWT
+                      regex: ^decode$
             - has:
                 kind: string
                 nthChild: 2
@@ -91,77 +178,39 @@ rule:
                   kind: string_fragment
                   regex: ^jwt-simple$
 
-        # TypeScript import-equals binding of the CommonJS module. The
-        # clause lives inside the import statement (the follows-visible
-        # sibling), and its require accepts exactly one string argument,
-        # so no arity guards are needed here.
-        - kind: import_statement
-          has:
-            kind: import_require_clause
-            all:
-              - has:
-                  kind: identifier
-                  pattern: $JWT
-              - has:
-                  stopBy: end
-                  kind: string
-                  has:
-                    kind: string_fragment
-                    regex: ^jwt-simple$
-
-        - kind: expression_statement
-          has:
-            kind: assignment_expression
-            all:
-              - has:
-                  kind: identifier
-                  pattern: $JWT
-                  nthChild: 1
-              - has:
-                  kind: call_expression
-                  nthChild: 2
-                  all:
-                    - has:
-                        nthChild: 1
-                        kind: identifier
-                        regex: ^require$
-                    - has:
-                        nthChild: 2
-                        kind: arguments
-                        has:
-                          stopBy: end
-                          kind: string
-                          nthChild: 1
-                          has:
-                            kind: string_fragment
-                            regex: ^jwt-simple$
-                          all:
-                            - not:
-                                has:
-                                  nthChild: 2
-                            - not:
-                                has:
-                                  stopBy: end
-                                  any:
-                                    - kind: object
-                                    - kind: array
-                                    - kind: pair
-
 constraints:
   NOVERIFY:
     all:
       - any:
-          - any:
-              - regex: ^true$
-              - kind: string
-              - kind: template_string
+          # A bare `true` or any non-empty string or constant template is
+          # truthy; non-empty literals carry a fragment child, which the
+          # fragment guard uses to exclude empty strings and templates.
+          - all:
+              - any:
+                  - regex: ^true$
+                  - all:
+                      - kind: string
+                      - has:
+                          kind: string_fragment
+                  - all:
+                      - kind: template_string
+                      - has:
+                          kind: string_fragment
           # Any unambiguous non-zero decimal is truthy, so it skips
-          # verification too; zero in any spelling and non-decimal forms
-          # like hex, binary, and exponents stay excluded because their
-          # value is not obvious from the literal alone.
+          # verification too; zero in any spelling (including negative
+          # zero) and non-decimal forms like hex, binary, and exponents
+          # stay excluded because their value is not obvious from the
+          # literal alone. A leading minus parses as a unary_expression,
+          # not a number, so negative and positive values need separate
+          # arms.
           - all:
               - kind: number
               - regex: ^(?:[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$
+          - all:
+              - kind: unary_expression
+              - has:
+                  kind: number
+                  regex: ^(?:[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$
           - has:
               stopBy: end
               any:

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -4,8 +4,9 @@ severity: warning
 message: >-
   Detected the decoding of a JWT token without a verify step. JWT tokens
   must be verified before use, otherwise the token's integrity is unknown.
-  This means a malicious actor could forge a JWT token with any claims. Set
-  'verify' to `true` before using the token.
+  This means a malicious actor could forge a JWT token with any claims.
+  Omit the third argument or pass `false` so jwt-simple verifies the
+  signature before the token is used.
 note: >-
   [CWE-287] Improper Authentication
   [CWE-345] Insufficient Verification of Data Authenticity
@@ -64,6 +65,50 @@ rule:
                                       - kind: array
                                       - kind: pair
 
+        # ES module import of jwt-simple.
+        - kind: import_statement
+          all:
+            - has:
+                kind: import_clause
+                any:
+                  - has:
+                      kind: namespace_import
+                      has:
+                        kind: identifier
+                        pattern: $JWT
+                  - has:
+                      kind: named_imports
+                      has:
+                        kind: import_specifier
+                        pattern: $JWT
+                  - has:
+                      kind: identifier
+                      pattern: $JWT
+            - has:
+                kind: string
+                nthChild: 2
+                has:
+                  kind: string_fragment
+                  regex: ^jwt-simple$
+
+        # TypeScript import-equals binding of the CommonJS module. The
+        # clause lives inside the import statement (the follows-visible
+        # sibling), and its require accepts exactly one string argument,
+        # so no arity guards are needed here.
+        - kind: import_statement
+          has:
+            kind: import_require_clause
+            all:
+              - has:
+                  kind: identifier
+                  pattern: $JWT
+              - has:
+                  stopBy: end
+                  kind: string
+                  has:
+                    kind: string_fragment
+                    regex: ^jwt-simple$
+
         - kind: expression_statement
           has:
             kind: assignment_expression
@@ -86,9 +131,21 @@ rule:
                         has:
                           stopBy: end
                           kind: string
+                          nthChild: 1
                           has:
                             kind: string_fragment
                             regex: ^jwt-simple$
+                          all:
+                            - not:
+                                has:
+                                  nthChild: 2
+                            - not:
+                                has:
+                                  stopBy: end
+                                  any:
+                                    - kind: object
+                                    - kind: array
+                                    - kind: pair
 
 constraints:
   NOVERIFY:
@@ -98,12 +155,13 @@ constraints:
               - regex: ^true$
               - kind: string
               - kind: template_string
-          # Any non-zero number is truthy, so it skips verification too;
-          # zero in any spelling is falsy and verifies normally.
+          # Any unambiguous non-zero decimal is truthy, so it skips
+          # verification too; zero in any spelling and non-decimal forms
+          # like hex, binary, and exponents stay excluded because their
+          # value is not obvious from the literal alone.
           - all:
               - kind: number
-              - not:
-                  regex: ^0+(?:\\.0+)?$
+              - regex: ^(?:[1-9][0-9]*(?:\\.[0-9]+)?|0*\\.[0-9]*[1-9][0-9]*)$
           - has:
               stopBy: end
               any:

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -1,5 +1,5 @@
 id: jwt-simple-noverify-typescript
-language: TypeScript
+language: typescript
 severity: warning
 message: >-
   "Detected the decoding of a JWT token without a verify step. JWT tokens

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -98,6 +98,12 @@ constraints:
               - regex: ^true$
               - kind: string
               - kind: template_string
+          # Any non-zero number is truthy, so it skips verification too;
+          # zero in any spelling is falsy and verifies normally.
+          - all:
+              - kind: number
+              - not:
+                  regex: ^0+(?:\\.0+)?$
           - has:
               stopBy: end
               any:

--- a/rules/typescript/security/jwt-simple-noverify-typescript.yml
+++ b/rules/typescript/security/jwt-simple-noverify-typescript.yml
@@ -2,10 +2,10 @@ id: jwt-simple-noverify-typescript
 language: typescript
 severity: warning
 message: >-
-  "Detected the decoding of a JWT token without a verify step. JWT tokens
-      must be verified before use, otherwise the token's integrity is unknown.
-      This means a malicious actor could forge a JWT token with any claims. Set
-      'verify' to `true` before using the token."
+  Detected the decoding of a JWT token without a verify step. JWT tokens
+  must be verified before use, otherwise the token's integrity is unknown.
+  This means a malicious actor could forge a JWT token with any claims. Set
+  'verify' to `true` before using the token.
 note: >-
   [CWE-287] Improper Authentication
   [CWE-345] Insufficient Verification of Data Authenticity

--- a/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
@@ -1,0 +1,173 @@
+id: node-sequelize-empty-password-argument-typescript
+language: typescript
+severity: warning
+message: >-
+  The application creates a database connection with an empty password.
+  This can lead to unauthorized access by either an internal or external
+  malicious actor. To prevent this vulnerability, enforce authentication
+  when connecting to a database by using environment variables to securely
+  provide credentials or retrieving them from a secure vault or HSM
+  (Hardware Security Module).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+ast-grep-essentials: true
+utils:
+  Match_pattern_directly:
+   kind: string
+   all:
+     - not:
+         has:
+           kind: string_fragment
+     - nthChild: 
+        position: 3
+        ofRule:
+          not:
+            kind: comment
+     - inside:
+         kind: arguments
+         all:
+           - has:
+               nthChild: 
+                position: 4
+                ofRule:
+                  not:
+                    kind: comment
+           - not:
+               has:
+                 nthChild: 
+                    position: 5
+                    ofRule:
+                      not:
+                        kind: comment
+           - inside:
+               kind: new_expression
+               all:
+               - has:
+                  kind: identifier
+                  pattern: $SQL
+               - any:
+                 - inside:
+                     stopBy: end
+                     follows:
+                      stopBy: end
+                      any:
+                        - pattern: $SQL = require('sequelize');
+                        - pattern: const $SQL = require('sequelize');
+                        - pattern: var $SQL = require('sequelize');
+                        - pattern: let $SQL = require('sequelize');
+                        - pattern: import $SQL from 'sequelize';
+                        - pattern: import * as $SQL from 'sequelize';
+                        - kind: import_statement
+                          all:
+                            - has:
+                                kind: import_clause
+                                has:
+                                  stopBy: end
+                                  pattern: $SQL
+                            - has:
+                                kind: string
+                                has:
+                                  kind: string_fragment
+                                  regex: ^sequelize$
+     - not:
+         inside:
+           stopBy: end
+           kind: enum_declaration
+           
+  Match_pattern_with_Instance:
+   kind: identifier
+   pattern: $PASS
+   all:
+     - nthChild: 
+        position: 3
+        ofRule:
+          not:
+            kind: comment
+     - inside:
+         kind: arguments
+         all:
+           - not:
+               has:
+                 nthChild: 
+                    position: 5
+                    ofRule:
+                      not:
+                        kind: comment
+           - has:
+               nthChild: 
+                position: 4
+                ofRule:
+                  not:
+                    kind: comment
+           - inside:
+               kind: new_expression
+               all:
+               - has:
+                  kind: identifier
+                  pattern: $SQL
+               - any:
+                 - inside:
+                     stopBy: end
+                     follows:
+                      stopBy: end
+                      any:
+                        - pattern: $SQL = require('sequelize');
+                        - pattern: const $SQL = require('sequelize');
+                        - pattern: var $SQL = require('sequelize');
+                        - pattern: let $SQL = require('sequelize');
+                        - pattern: import $SQL from 'sequelize';
+                        - pattern: import * as $SQL from 'sequelize';
+                        - kind: import_statement
+                          all:
+                            - has:
+                                kind: import_clause
+                                has:
+                                  stopBy: end
+                                  pattern: $SQL
+                            - has:
+                                kind: string
+                                has:
+                                  kind: string_fragment
+                                  regex: ^sequelize$
+     - inside:
+         stopBy: end
+         follows:
+           stopBy: end
+           any:
+             - kind: lexical_declaration
+               has:
+                kind: variable_declarator
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $PASS
+                  - has:
+                     any:
+                      - kind: template_string
+                        regex: ^``$
+                      - kind: string
+                        not:
+                         has:
+                          kind: string_fragment
+             - kind: variable_declaration
+               has:
+                kind: variable_declarator
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $PASS
+                  - has:
+                      kind: string
+                      not:
+                        has:
+                          kind: string_fragment
+     - not:
+         inside:
+           stopBy: end
+           kind: enum_declaration
+rule:
+ any:
+   - matches: Match_pattern_directly
+   - matches: Match_pattern_with_Instance

--- a/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
@@ -17,11 +17,13 @@ utils:
   Match_pattern_directly:
    all:
      - any:
-         - kind: string
+         - all:
+             - kind: string
+             - not:
+                 has:
+                   kind: string_fragment
          - kind: template_string
-     - not:
-         has:
-           kind: string_fragment
+           regex: ^``$
      - nthChild: 
         position: 3
         ofRule:

--- a/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
@@ -15,8 +15,10 @@ note: >-
 ast-grep-essentials: true
 utils:
   Match_pattern_directly:
-   kind: string
    all:
+     - any:
+         - kind: string
+         - kind: template_string
      - not:
          has:
            kind: string_fragment
@@ -154,11 +156,15 @@ utils:
                   - has:
                       kind: identifier
                       pattern: $PASS
-                  - has:
-                      kind: string
-                      not:
-                        has:
-                          kind: string_fragment
+                  - any:
+                      - has:
+                          kind: string
+                          not:
+                            has:
+                              kind: string_fragment
+                      - has:
+                          kind: template_string
+                          regex: ^``$
      - not:
          inside:
            stopBy: end

--- a/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-empty-password-argument-typescript.yml
@@ -28,12 +28,6 @@ utils:
      - inside:
          kind: arguments
          all:
-           - has:
-               nthChild: 
-                position: 4
-                ofRule:
-                  not:
-                    kind: comment
            - not:
                has:
                  nthChild: 
@@ -54,9 +48,13 @@ utils:
                       stopBy: end
                       any:
                         - pattern: $SQL = require('sequelize');
+                        - pattern: $SQL = require("sequelize");
                         - pattern: const $SQL = require('sequelize');
+                        - pattern: const $SQL = require("sequelize");
                         - pattern: var $SQL = require('sequelize');
+                        - pattern: var $SQL = require("sequelize");
                         - pattern: let $SQL = require('sequelize');
+                        - pattern: let $SQL = require("sequelize");
                         - pattern: import $SQL from 'sequelize';
                         - pattern: import * as $SQL from 'sequelize';
                         - kind: import_statement
@@ -95,12 +93,6 @@ utils:
                     ofRule:
                       not:
                         kind: comment
-           - has:
-               nthChild: 
-                position: 4
-                ofRule:
-                  not:
-                    kind: comment
            - inside:
                kind: new_expression
                all:
@@ -114,9 +106,13 @@ utils:
                       stopBy: end
                       any:
                         - pattern: $SQL = require('sequelize');
+                        - pattern: $SQL = require("sequelize");
                         - pattern: const $SQL = require('sequelize');
+                        - pattern: const $SQL = require("sequelize");
                         - pattern: var $SQL = require('sequelize');
+                        - pattern: var $SQL = require("sequelize");
                         - pattern: let $SQL = require('sequelize');
+                        - pattern: let $SQL = require("sequelize");
                         - pattern: import $SQL from 'sequelize';
                         - pattern: import * as $SQL from 'sequelize';
                         - kind: import_statement

--- a/rules/typescript/security/node-sequelize-hardcoded-secret-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-hardcoded-secret-argument-typescript.yml
@@ -1,0 +1,158 @@
+id: node-sequelize-hardcoded-secret-argument-typescript
+language: typescript
+severity: warning
+message: >-
+  A secret is hard-coded in the application. Secrets stored in source
+  code, such as credentials, identifiers, and other types of sensitive data,
+  can be leaked and used by internal or external malicious actors. Use
+  environment variables to securely provide credentials and other secrets or
+  retrieve them from a secure vault or Hardware Security Module (HSM).
+note: >-
+  [CWE-287] Improper Authentication.
+  [REFERENCES]
+      - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+ast-grep-essentials: true
+utils:
+  Match_pattern_directly:
+   kind: string
+   all:
+     - has:
+           kind: string_fragment
+     - nthChild: 
+        position: 3
+        ofRule:
+          not:
+            kind: comment
+     - inside:
+         kind: arguments
+         all:
+           - has:
+               nthChild: 
+                position: 4
+                ofRule:
+                  not:
+                    kind: comment
+           - not:
+               has:
+                 nthChild: 
+                    position: 5
+                    ofRule:
+                      not:
+                        kind: comment
+           - inside:
+               kind: new_expression
+               all:
+               - has:
+                  kind: identifier
+                  pattern: $SQL
+               - any:
+                 - inside:
+                     stopBy: end
+                     follows:
+                      stopBy: end
+                      any:
+                        - pattern: $SQL = require('sequelize');
+                        - pattern: const $SQL = require('sequelize');
+                        - pattern: var $SQL = require('sequelize');
+                        - pattern: let $SQL = require('sequelize');
+                        - pattern: import $SQL from 'sequelize';
+                        - pattern: import * as $SQL from 'sequelize';
+                        - kind: import_statement
+                          all:
+                            - has:
+                                kind: import_clause
+                                has:
+                                  stopBy: end
+                                  pattern: $SQL
+                            - has:
+                                kind: string
+                                has:
+                                  kind: string_fragment
+                                  regex: ^sequelize$
+     - not:
+         inside:
+           stopBy: end
+           kind: enum_declaration
+           
+  Match_pattern_with_Instance:
+   kind: identifier
+   pattern: $PASS
+   all:
+     - nthChild: 
+        position: 3
+        ofRule:
+          not:
+            kind: comment
+     - inside:
+         kind: arguments
+         all:
+           - not:
+               has:
+                 nthChild: 
+                    position: 5
+                    ofRule:
+                      not:
+                        kind: comment
+           - has:
+               nthChild: 
+                position: 4
+                ofRule:
+                  not:
+                    kind: comment
+           - inside:
+               kind: new_expression
+               all:
+               - has:
+                  kind: identifier
+                  pattern: $SQL
+               - any:
+                 - inside:
+                     stopBy: end
+                     follows:
+                      stopBy: end
+                      any:
+                        - pattern: $SQL = require('sequelize');
+                        - pattern: const $SQL = require('sequelize');
+                        - pattern: var $SQL = require('sequelize');
+                        - pattern: let $SQL = require('sequelize');
+                        - pattern: import $SQL from 'sequelize';
+                        - pattern: import * as $SQL from 'sequelize';
+                        - kind: import_statement
+                          all:
+                            - has:
+                                kind: import_clause
+                                has:
+                                  stopBy: end
+                                  pattern: $SQL
+                            - has:
+                                kind: string
+                                has:
+                                  kind: string_fragment
+                                  regex: ^sequelize$
+     - inside:
+         stopBy: end
+         follows:
+           stopBy: end
+           any:
+             - kind: lexical_declaration
+               not:
+                 has:
+                   regex: ^let$
+               has:
+                kind: variable_declarator
+                all:
+                  - has:
+                      kind: identifier
+                      pattern: $PASS
+                  - has:
+                     kind: string
+                     has:
+                       kind: string_fragment
+     - not:
+         inside:
+           stopBy: end
+           kind: enum_declaration
+rule:
+ any:
+   - matches: Match_pattern_directly
+   - matches: Match_pattern_with_Instance

--- a/rules/typescript/security/node-sequelize-hardcoded-secret-argument-typescript.yml
+++ b/rules/typescript/security/node-sequelize-hardcoded-secret-argument-typescript.yml
@@ -8,7 +8,7 @@ message: >-
   environment variables to securely provide credentials and other secrets or
   retrieve them from a secure vault or Hardware Security Module (HSM).
 note: >-
-  [CWE-287] Improper Authentication.
+  [CWE-798] Use of Hard-coded Credentials.
   [REFERENCES]
       - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
 ast-grep-essentials: true
@@ -26,12 +26,6 @@ utils:
      - inside:
          kind: arguments
          all:
-           - has:
-               nthChild: 
-                position: 4
-                ofRule:
-                  not:
-                    kind: comment
            - not:
                has:
                  nthChild: 
@@ -52,9 +46,13 @@ utils:
                       stopBy: end
                       any:
                         - pattern: $SQL = require('sequelize');
+                        - pattern: $SQL = require("sequelize");
                         - pattern: const $SQL = require('sequelize');
+                        - pattern: const $SQL = require("sequelize");
                         - pattern: var $SQL = require('sequelize');
+                        - pattern: var $SQL = require("sequelize");
                         - pattern: let $SQL = require('sequelize');
+                        - pattern: let $SQL = require("sequelize");
                         - pattern: import $SQL from 'sequelize';
                         - pattern: import * as $SQL from 'sequelize';
                         - kind: import_statement
@@ -93,12 +91,6 @@ utils:
                     ofRule:
                       not:
                         kind: comment
-           - has:
-               nthChild: 
-                position: 4
-                ofRule:
-                  not:
-                    kind: comment
            - inside:
                kind: new_expression
                all:
@@ -112,9 +104,13 @@ utils:
                       stopBy: end
                       any:
                         - pattern: $SQL = require('sequelize');
+                        - pattern: $SQL = require("sequelize");
                         - pattern: const $SQL = require('sequelize');
+                        - pattern: const $SQL = require("sequelize");
                         - pattern: var $SQL = require('sequelize');
+                        - pattern: var $SQL = require("sequelize");
                         - pattern: let $SQL = require('sequelize');
+                        - pattern: let $SQL = require("sequelize");
                         - pattern: import $SQL from 'sequelize';
                         - pattern: import * as $SQL from 'sequelize';
                         - kind: import_statement

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -41,6 +41,11 @@ else
   npm run fix
 fi
 
+echo "Running ast-grep scan..."
+# Vendored essentials rules; --error promotes all rules so findings exit 1 and
+# regressions surface at CI time.
+npx ast-grep scan --error
+
 echo "Running unit tests..."
 # Timeout protects against import hangs (vitest testTimeout only applies to test execution)
 # Tests normally complete in ~2-3 seconds; 60s allows generous headroom

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,9 +42,14 @@ else
 fi
 
 echo "Running ast-grep scan..."
-# Vendored essentials rules; --error promotes all rules so findings exit 1 and
-# regressions surface at CI time.
+# Project-maintained rules (derived from ast-grep-essentials); --error
+# promotes all rules so findings exit 1 and regressions surface at CI time.
 npx ast-grep scan --error
+
+echo "Running ast-grep rule tests..."
+# Snapshot tests hold the rules' semantic contract, so rule edits and
+# re-vendors are judged against the recorded probe matrix.
+npx ast-grep test -t tests/ast-grep
 
 echo "Running unit tests..."
 # Timeout protects against import hangs (vitest testTimeout only applies to test execution)

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,12 +1,18 @@
 ---
-# ast-grep project configuration for `ast-grep scan`.
+# ast-grep project configuration for `ast-grep scan` and `ast-grep test`.
 #
-# The rules under `rules/` are the TypeScript security subset of the
-# coderabbitai/ast-grep-essentials package (Apache-2.0), the default preset
-# CodeRabbit runs. Vendored here so CI scans offline; the full upstream
-# package is at https://github.com/coderabbitai/ast-grep-essentials.
+# The rules under `rules/` are project-maintained, originally derived from
+# the TypeScript security subset of the coderabbitai/ast-grep-essentials
+# package (Apache-2.0, the default preset CodeRabbit runs). Attribution is
+# retained in `rules/ESSENTIALS-LICENSE.txt`; the full upstream package is
+# at https://github.com/coderabbitai/ast-grep-essentials.
 #
-# Run locally: `ast-grep scan` (or `sg scan`).
+# The semantic contract of every rule lives in `tests/ast-grep/` and runs in
+# CI, so rule edits and re-vendors are judged against the recorded probe
+# matrix rather than by review alone.
+#
+# Run locally: `ast-grep scan` (or `sg scan`), or
+# `ast-grep test -t tests/ast-grep` for the rule tests.
 #
 # Four rules carry local fixes that are NOT upstream yet, so re-vendoring
 # from ast-grep-essentials must reconcile them instead of overwriting:

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -17,28 +17,30 @@
 # Four rules carry local fixes that are NOT upstream yet, so re-vendoring
 # from ast-grep-essentials must reconcile them instead of overwriting:
 # - `express-session-hardcoded-secret-typescript.yml` matches module
-#   specifiers quote-agnostically, accepts `var` requires, and detects
-#   backtick secrets, quoted `"secret"` keys, and rotation arrays that
-#   contain any constant secret (upstream only matches single quotes,
-#   unquoted keys, `const`/`let`/assignment requires, and single quoted
-#   strings; single quotes never occur here because biome enforces
-#   double quotes).
+#   specifiers quote-agnostically, accepts `var` requires, pins the module
+#   name to the first `require` argument, and detects backtick secrets,
+#   quoted `"secret"` keys, and rotation arrays that contain any constant
+#   secret (upstream only matches single quotes, unquoted keys,
+#   `const`/`let`/assignment requires, and single quoted strings; single
+#   quotes never occur here because biome enforces double quotes).
 # - both `node-sequelize-*` rules detect three- and four-argument
 #   constructor calls, double-quoted `require` calls, and empty backtick
-#   passwords, and the hardcoded-secret rule carries the correct CWE-798
-#   classification (upstream requires four arguments, single quotes, and
-#   quoted strings only, and mislabels CWE-287). Five-or-more-argument
-#   calls stay out of scope on purpose: the `position: 5` guard mirrors
-#   upstream's boundary, and Sequelize's canonical constructor is
-#   `(database, username, password, options)`, so argument three is only
-#   known to be the password up to four arguments.
+#   passwords while treating interpolated templates as non-empty, and the
+#   hardcoded-secret rule carries the correct CWE-798 classification
+#   (upstream requires four arguments, single quotes, and quoted strings
+#   only, and mislabels CWE-287). Five-or-more-argument calls stay out of
+#   scope on purpose: the `position: 5` guard mirrors upstream's boundary,
+#   and Sequelize's canonical constructor is `(database, username, password,
+#   options)`, so argument three is only known to be the password up to
+#   four arguments.
 # - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript`, a
 #   properly folded message with correct remediation guidance, import
 #   forms for ES imports, import-equals bindings, and named-import
-#   destructuring, a require matcher that pins the module name to the
-#   first and only string argument, and a no-verify matcher that accepts
-#   non-empty strings and templates plus unambiguous non-zero decimals
-#   (signed or unsigned) while excluding empty and zero literals (upstream
+#   destructuring (including aliased imports), a require matcher that pins
+#   the module name to the first and only string argument, and a no-verify
+#   matcher that accepts non-empty strings and templates plus unambiguous
+#   non-zero decimals while excluding empty and zero literals and treating
+#   only sign-prefixed unary `+`/`-` numbers as truthy (upstream
 #   capitalizes the language inconsistently, renders the diagnostic with
 #   stray quotes and inverted guidance, accepts no imports, and misses
 #   numeric truthy flags).

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -8,7 +8,7 @@
 #
 # Run locally: `ast-grep scan` (or `sg scan`).
 #
-# Two rules carry local fixes that are NOT upstream yet, so re-vendoring
+# Four rules carry local fixes that are NOT upstream yet, so re-vendoring
 # from ast-grep-essentials must reconcile them instead of overwriting:
 # - `express-session-hardcoded-secret-typescript.yml` matches module
 #   specifiers quote-agnostically, accepts `var` requires, and detects
@@ -19,5 +19,8 @@
 #   calls and double-quoted `require` calls, and the hardcoded-secret
 #   rule carries the correct CWE-798 classification (upstream requires
 #   four arguments, single quotes, and mislabels CWE-287).
+# - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript` and
+#   a properly folded message scalar (upstream capitalizes the language
+#   inconsistently and renders the diagnostic with stray quotes).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -30,11 +30,13 @@
 #   quoted strings only, and mislabels CWE-287).
 # - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript`, a
 #   properly folded message with correct remediation guidance, import
-#   forms for both ES imports and import-equals bindings, a require
-#   matcher that pins the module name to the first and only string
-#   argument, and a no-verify matcher for unambiguous non-zero decimals
-#   (upstream capitalizes the language inconsistently, renders the
-#   diagnostic with stray quotes and inverted guidance, accepts no
-#   imports, and misses numeric truthy flags).
+#   forms for ES imports, import-equals bindings, and named-import
+#   destructuring, a require matcher that pins the module name to the
+#   first and only string argument, and a no-verify matcher that accepts
+#   non-empty strings and templates plus unambiguous non-zero decimals
+#   (signed or unsigned) while excluding empty and zero literals (upstream
+#   capitalizes the language inconsistently, renders the diagnostic with
+#   stray quotes and inverted guidance, accepts no imports, and misses
+#   numeric truthy flags).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -15,8 +15,9 @@
 #   backtick secrets (upstream only matches single quotes and `const`/
 #   `let`/assignment requires, and quoted strings only; single quotes
 #   never occur here because biome enforces double quotes).
-# - `node-sequelize-empty-password-argument-typescript.yml` detects
-#   three-argument constructor calls and double-quoted `require` calls
-#   (upstream requires four arguments and single quotes).
+# - both `node-sequelize-*` rules detect three-argument constructor
+#   calls and double-quoted `require` calls, and the hardcoded-secret
+#   rule carries the correct CWE-798 classification (upstream requires
+#   four arguments, single quotes, and mislabels CWE-287).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -16,9 +16,10 @@
 #   `let`/assignment requires, and quoted strings only; single quotes
 #   never occur here because biome enforces double quotes).
 # - both `node-sequelize-*` rules detect three-argument constructor
-#   calls and double-quoted `require` calls, and the hardcoded-secret
-#   rule carries the correct CWE-798 classification (upstream requires
-#   four arguments, single quotes, and mislabels CWE-287).
+#   calls, double-quoted `require` calls, and empty backtick passwords,
+#   and the hardcoded-secret rule carries the correct CWE-798
+#   classification (upstream requires four arguments, single quotes, and
+#   quoted strings only, and mislabels CWE-287).
 # - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript` and
 #   a properly folded message scalar (upstream capitalizes the language
 #   inconsistently and renders the diagnostic with stray quotes).

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -18,19 +18,23 @@
 # from ast-grep-essentials must reconcile them instead of overwriting:
 # - `express-session-hardcoded-secret-typescript.yml` matches module
 #   specifiers quote-agnostically, accepts `var` requires, and detects
-#   backtick secrets and rotation arrays that contain any constant secret
-#   (upstream only matches single quotes and `const`/`let`/assignment
-#   requires, and single quoted strings only; single quotes never occur
-#   here because biome enforces double quotes).
+#   backtick secrets, quoted `"secret"` keys, and rotation arrays that
+#   contain any constant secret (upstream only matches single quotes,
+#   unquoted keys, `const`/`let`/assignment requires, and single quoted
+#   strings; single quotes never occur here because biome enforces
+#   double quotes).
 # - both `node-sequelize-*` rules detect three-argument constructor
 #   calls, double-quoted `require` calls, and empty backtick passwords,
 #   and the hardcoded-secret rule carries the correct CWE-798
 #   classification (upstream requires four arguments, single quotes, and
 #   quoted strings only, and mislabels CWE-287).
 # - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript`, a
-#   properly folded message scalar, and a no-verify matcher that accepts
-#   any truthy literal including non-zero numbers (upstream capitalizes
-#   the language inconsistently, renders the diagnostic with stray
-#   quotes, and misses numeric truthy flags).
+#   properly folded message with correct remediation guidance, import
+#   forms for both ES imports and import-equals bindings, a require
+#   matcher that pins the module name to the first and only string
+#   argument, and a no-verify matcher for unambiguous non-zero decimals
+#   (upstream capitalizes the language inconsistently, renders the
+#   diagnostic with stray quotes and inverted guidance, accepts no
+#   imports, and misses numeric truthy flags).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -18,16 +18,19 @@
 # from ast-grep-essentials must reconcile them instead of overwriting:
 # - `express-session-hardcoded-secret-typescript.yml` matches module
 #   specifiers quote-agnostically, accepts `var` requires, and detects
-#   backtick secrets (upstream only matches single quotes and `const`/
-#   `let`/assignment requires, and quoted strings only; single quotes
-#   never occur here because biome enforces double quotes).
+#   backtick secrets and rotation arrays that contain any constant secret
+#   (upstream only matches single quotes and `const`/`let`/assignment
+#   requires, and single quoted strings only; single quotes never occur
+#   here because biome enforces double quotes).
 # - both `node-sequelize-*` rules detect three-argument constructor
 #   calls, double-quoted `require` calls, and empty backtick passwords,
 #   and the hardcoded-secret rule carries the correct CWE-798
 #   classification (upstream requires four arguments, single quotes, and
 #   quoted strings only, and mislabels CWE-287).
-# - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript` and
-#   a properly folded message scalar (upstream capitalizes the language
-#   inconsistently and renders the diagnostic with stray quotes).
+# - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript`, a
+#   properly folded message scalar, and a no-verify matcher that accepts
+#   any truthy literal including non-zero numbers (upstream capitalizes
+#   the language inconsistently, renders the diagnostic with stray
+#   quotes, and misses numeric truthy flags).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -23,11 +23,15 @@
 #   unquoted keys, `const`/`let`/assignment requires, and single quoted
 #   strings; single quotes never occur here because biome enforces
 #   double quotes).
-# - both `node-sequelize-*` rules detect three-argument constructor
-#   calls, double-quoted `require` calls, and empty backtick passwords,
-#   and the hardcoded-secret rule carries the correct CWE-798
+# - both `node-sequelize-*` rules detect three- and four-argument
+#   constructor calls, double-quoted `require` calls, and empty backtick
+#   passwords, and the hardcoded-secret rule carries the correct CWE-798
 #   classification (upstream requires four arguments, single quotes, and
-#   quoted strings only, and mislabels CWE-287).
+#   quoted strings only, and mislabels CWE-287). Five-or-more-argument
+#   calls stay out of scope on purpose: the `position: 5` guard mirrors
+#   upstream's boundary, and Sequelize's canonical constructor is
+#   `(database, username, password, options)`, so argument three is only
+#   known to be the password up to four arguments.
 # - `jwt-simple-noverify-typescript.yml` uses lowercase `typescript`, a
 #   properly folded message with correct remediation guidance, import
 #   forms for ES imports, import-equals bindings, and named-import

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,11 @@
+---
+# ast-grep project configuration for `ast-grep scan`.
+#
+# The rules under `rules/` are the TypeScript security subset of the
+# coderabbitai/ast-grep-essentials package (Apache-2.0), the default preset
+# CodeRabbit runs. Vendored here so CI scans offline; the full upstream
+# package is at https://github.com/coderabbitai/ast-grep-essentials.
+#
+# Run locally: `ast-grep scan` (or `sg scan`).
+ruleDirs:
+  - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -7,5 +7,14 @@
 # package is at https://github.com/coderabbitai/ast-grep-essentials.
 #
 # Run locally: `ast-grep scan` (or `sg scan`).
+#
+# Two rules carry local fixes that are NOT upstream yet, so re-vendoring
+# from ast-grep-essentials must reconcile them instead of overwriting:
+# - `express-session-hardcoded-secret-typescript.yml` matches module
+#   specifiers quote-agnostically (upstream only matches single quotes,
+#   which never occurs here because biome enforces double quotes).
+# - `node-sequelize-empty-password-argument-typescript.yml` detects
+#   three-argument constructor calls and double-quoted `require` calls
+#   (upstream requires four arguments and single quotes).
 ruleDirs:
   - rules

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -11,8 +11,10 @@
 # Two rules carry local fixes that are NOT upstream yet, so re-vendoring
 # from ast-grep-essentials must reconcile them instead of overwriting:
 # - `express-session-hardcoded-secret-typescript.yml` matches module
-#   specifiers quote-agnostically (upstream only matches single quotes,
-#   which never occurs here because biome enforces double quotes).
+#   specifiers quote-agnostically, accepts `var` requires, and detects
+#   backtick secrets (upstream only matches single quotes and `const`/
+#   `let`/assignment requires, and quoted strings only; single quotes
+#   never occur here because biome enforces double quotes).
 # - `node-sequelize-empty-password-argument-typescript.yml` detects
 #   three-argument constructor calls and double-quoted `require` calls
 #   (upstream requires four arguments and single quotes).

--- a/tests/ast-grep/__snapshots__/detect-angular-sce-disabled-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/detect-angular-sce-disabled-typescript-snapshot.yml
@@ -1,0 +1,32 @@
+id: detect-angular-sce-disabled-typescript
+snapshots:
+  $sceProvider.enabled(false);:
+    labels:
+    - source: $sceProvider.enabled(false);
+      style: primary
+      start: 0
+      end: 28
+    - source: $sceProvider
+      style: secondary
+      start: 0
+      end: 12
+    - source: enabled
+      style: secondary
+      start: 13
+      end: 20
+    - source: 'false'
+      style: secondary
+      start: 21
+      end: 26
+    - source: (false)
+      style: secondary
+      start: 20
+      end: 27
+    - source: $sceProvider.enabled
+      style: secondary
+      start: 0
+      end: 20
+    - source: $sceProvider.enabled(false)
+      style: secondary
+      start: 0
+      end: 27

--- a/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
@@ -1,0 +1,508 @@
+id: express-session-hardcoded-secret-typescript
+snapshots:
+  ? |-
+    const session = require("express-session");
+    app.use(session({ secret: "hunter2" }));
+  : labels:
+    - source: 'secret: "hunter2"'
+      style: primary
+      start: 62
+      end: 79
+    - source: secret
+      style: secondary
+      start: 62
+      end: 68
+    - source: '"hunter2"'
+      style: secondary
+      start: 70
+      end: 79
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ secret: "hunter2" }))'
+      style: secondary
+      start: 44
+      end: 83
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 60
+      end: 81
+  ? |-
+    const session = require("express-session");
+    app.use(session({ secret: `hunter2` }));
+  : labels:
+    - source: 'secret: `hunter2`'
+      style: primary
+      start: 62
+      end: 79
+    - source: secret
+      style: secondary
+      start: 62
+      end: 68
+    - source: '`hunter2`'
+      style: secondary
+      start: 70
+      end: 79
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ secret: `hunter2` }))'
+      style: secondary
+      start: 44
+      end: 83
+    - source: '{ secret: `hunter2` }'
+      style: secondary
+      start: 60
+      end: 81
+  ? |-
+    const session = require("express-session");
+    const opts = { secret: "hunter2" };
+    app.use(session(opts));
+  : labels:
+    - source: 'secret: "hunter2"'
+      style: primary
+      start: 59
+      end: 76
+    - source: secret
+      style: secondary
+      start: 59
+      end: 65
+    - source: '"hunter2"'
+      style: secondary
+      start: 67
+      end: 76
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 57
+      end: 78
+    - source: opts
+      style: secondary
+      start: 50
+      end: 54
+    - source: 'opts = { secret: "hunter2" }'
+      style: secondary
+      start: 50
+      end: 78
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: opts
+      style: secondary
+      start: 96
+      end: 100
+    - source: app.use(session(opts))
+      style: secondary
+      start: 80
+      end: 102
+    - source: app.use(session(opts))
+      style: secondary
+      start: 80
+      end: 102
+    - source: 'const opts = { secret: "hunter2" };'
+      style: secondary
+      start: 44
+      end: 79
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 57
+      end: 78
+  ? |-
+    const session = require("express-session");
+    let opts; opts = { secret: "hunter2" };
+    app.use(session(opts));
+  : labels:
+    - source: 'secret: "hunter2"'
+      style: primary
+      start: 63
+      end: 80
+    - source: secret
+      style: secondary
+      start: 63
+      end: 69
+    - source: '"hunter2"'
+      style: secondary
+      start: 71
+      end: 80
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 61
+      end: 82
+    - source: opts
+      style: secondary
+      start: 54
+      end: 58
+    - source: 'opts = { secret: "hunter2" }'
+      style: secondary
+      start: 54
+      end: 82
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: opts
+      style: secondary
+      start: 100
+      end: 104
+    - source: app.use(session(opts))
+      style: secondary
+      start: 84
+      end: 106
+    - source: app.use(session(opts))
+      style: secondary
+      start: 84
+      end: 106
+    - source: 'opts = { secret: "hunter2" };'
+      style: secondary
+      start: 54
+      end: 83
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 61
+      end: 82
+  ? |-
+    const session = require('express-session');
+    app.use(session({ secret: 'hunter2' }));
+  : labels:
+    - source: 'secret: ''hunter2'''
+      style: primary
+      start: 62
+      end: 79
+    - source: secret
+      style: secondary
+      start: 62
+      end: 68
+    - source: '''hunter2'''
+      style: secondary
+      start: 70
+      end: 79
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '''express-session'''
+      style: secondary
+      start: 24
+      end: 41
+    - source: ('express-session')
+      style: secondary
+      start: 23
+      end: 42
+    - source: require('express-session')
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require('express-session')
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require('express-session');
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require('express-session');
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ secret: ''hunter2'' }))'
+      style: secondary
+      start: 44
+      end: 83
+    - source: '{ secret: ''hunter2'' }'
+      style: secondary
+      start: 60
+      end: 81
+  ? |-
+    import session from "express-session";
+    app.use(session({ secret: "hunter2", resave: false }));
+  : labels:
+    - source: 'secret: "hunter2"'
+      style: primary
+      start: 57
+      end: 74
+    - source: secret
+      style: secondary
+      start: 57
+      end: 63
+    - source: '"hunter2"'
+      style: secondary
+      start: 65
+      end: 74
+    - source: session
+      style: secondary
+      start: 7
+      end: 14
+    - source: session
+      style: secondary
+      start: 7
+      end: 14
+    - source: express-session
+      style: secondary
+      start: 21
+      end: 36
+    - source: '"express-session"'
+      style: secondary
+      start: 20
+      end: 37
+    - source: import session from "express-session";
+      style: secondary
+      start: 0
+      end: 38
+    - source: import session from "express-session";
+      style: secondary
+      start: 0
+      end: 38
+    - source: 'app.use(session({ secret: "hunter2", resave: false }))'
+      style: secondary
+      start: 39
+      end: 93
+    - source: '{ secret: "hunter2", resave: false }'
+      style: secondary
+      start: 55
+      end: 91
+  ? |-
+    import session from 'express-session';
+    app.use(session({ secret: 'hunter2', resave: false }));
+  : labels:
+    - source: 'secret: ''hunter2'''
+      style: primary
+      start: 57
+      end: 74
+    - source: secret
+      style: secondary
+      start: 57
+      end: 63
+    - source: '''hunter2'''
+      style: secondary
+      start: 65
+      end: 74
+    - source: session
+      style: secondary
+      start: 7
+      end: 14
+    - source: session
+      style: secondary
+      start: 7
+      end: 14
+    - source: express-session
+      style: secondary
+      start: 21
+      end: 36
+    - source: '''express-session'''
+      style: secondary
+      start: 20
+      end: 37
+    - source: import session from 'express-session';
+      style: secondary
+      start: 0
+      end: 38
+    - source: import session from 'express-session';
+      style: secondary
+      start: 0
+      end: 38
+    - source: 'app.use(session({ secret: ''hunter2'', resave: false }))'
+      style: secondary
+      start: 39
+      end: 93
+    - source: '{ secret: ''hunter2'', resave: false }'
+      style: secondary
+      start: 55
+      end: 91
+  ? |-
+    var session = require("express-session");
+    app.use(session({ secret: "hunter2" }));
+  : labels:
+    - source: 'secret: "hunter2"'
+      style: primary
+      start: 60
+      end: 77
+    - source: secret
+      style: secondary
+      start: 60
+      end: 66
+    - source: '"hunter2"'
+      style: secondary
+      start: 68
+      end: 77
+    - source: session
+      style: secondary
+      start: 4
+      end: 11
+    - source: require
+      style: secondary
+      start: 14
+      end: 21
+    - source: express-session
+      style: secondary
+      start: 23
+      end: 38
+    - source: '"express-session"'
+      style: secondary
+      start: 22
+      end: 39
+    - source: ("express-session")
+      style: secondary
+      start: 21
+      end: 40
+    - source: require("express-session")
+      style: secondary
+      start: 14
+      end: 40
+    - source: session = require("express-session")
+      style: secondary
+      start: 4
+      end: 40
+    - source: var session = require("express-session");
+      style: secondary
+      start: 0
+      end: 41
+    - source: var session = require("express-session");
+      style: secondary
+      start: 0
+      end: 41
+    - source: 'app.use(session({ secret: "hunter2" }))'
+      style: secondary
+      start: 42
+      end: 81
+    - source: '{ secret: "hunter2" }'
+      style: secondary
+      start: 58
+      end: 79

--- a/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
@@ -62,6 +62,134 @@ snapshots:
       end: 81
   ? |-
     const session = require("express-session");
+    app.use(session({ secret: ["hunter2", "old-secret"] }));
+  : labels:
+    - source: 'secret: ["hunter2", "old-secret"]'
+      style: primary
+      start: 62
+      end: 95
+    - source: secret
+      style: secondary
+      start: 62
+      end: 68
+    - source: '"hunter2"'
+      style: secondary
+      start: 71
+      end: 80
+    - source: '["hunter2", "old-secret"]'
+      style: secondary
+      start: 70
+      end: 95
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ secret: ["hunter2", "old-secret"] }))'
+      style: secondary
+      start: 44
+      end: 99
+    - source: '{ secret: ["hunter2", "old-secret"] }'
+      style: secondary
+      start: 60
+      end: 97
+  ? |-
+    const session = require("express-session");
+    app.use(session({ secret: [process.env.SECRET, "fallback"] }));
+  : labels:
+    - source: 'secret: [process.env.SECRET, "fallback"]'
+      style: primary
+      start: 62
+      end: 102
+    - source: secret
+      style: secondary
+      start: 62
+      end: 68
+    - source: '"fallback"'
+      style: secondary
+      start: 91
+      end: 101
+    - source: '[process.env.SECRET, "fallback"]'
+      style: secondary
+      start: 70
+      end: 102
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ secret: [process.env.SECRET, "fallback"] }))'
+      style: secondary
+      start: 44
+      end: 106
+    - source: '{ secret: [process.env.SECRET, "fallback"] }'
+      style: secondary
+      start: 60
+      end: 104
+  ? |-
+    const session = require("express-session");
     app.use(session({ secret: `hunter2` }));
   : labels:
     - source: 'secret: `hunter2`'

--- a/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/express-session-hardcoded-secret-typescript-snapshot.yml
@@ -2,6 +2,70 @@ id: express-session-hardcoded-secret-typescript
 snapshots:
   ? |-
     const session = require("express-session");
+    app.use(session({ "secret": "hunter2" }));
+  : labels:
+    - source: '"secret": "hunter2"'
+      style: primary
+      start: 62
+      end: 81
+    - source: secret
+      style: secondary
+      start: 63
+      end: 69
+    - source: '"secret"'
+      style: secondary
+      start: 62
+      end: 70
+    - source: '"hunter2"'
+      style: secondary
+      start: 72
+      end: 81
+    - source: session
+      style: secondary
+      start: 6
+      end: 13
+    - source: require
+      style: secondary
+      start: 16
+      end: 23
+    - source: express-session
+      style: secondary
+      start: 25
+      end: 40
+    - source: '"express-session"'
+      style: secondary
+      start: 24
+      end: 41
+    - source: ("express-session")
+      style: secondary
+      start: 23
+      end: 42
+    - source: require("express-session")
+      style: secondary
+      start: 16
+      end: 42
+    - source: session = require("express-session")
+      style: secondary
+      start: 6
+      end: 42
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: const session = require("express-session");
+      style: secondary
+      start: 0
+      end: 43
+    - source: 'app.use(session({ "secret": "hunter2" }))'
+      style: secondary
+      start: 44
+      end: 85
+    - source: '{ "secret": "hunter2" }'
+      style: secondary
+      start: 60
+      end: 83
+  ? |-
+    const session = require("express-session");
     app.use(session({ secret: "hunter2" }));
   : labels:
     - source: 'secret: "hunter2"'

--- a/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
@@ -1,0 +1,90 @@
+id: jwt-simple-noverify-typescript
+snapshots:
+  ? |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, true);
+  : labels:
+    - source: jwt.decode(token, secret, true)
+      style: primary
+      start: 51
+      end: 82
+    - source: jwt
+      style: secondary
+      start: 6
+      end: 9
+    - source: require
+      style: secondary
+      start: 12
+      end: 19
+    - source: jwt-simple
+      style: secondary
+      start: 21
+      end: 31
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 20
+      end: 32
+    - source: ("jwt-simple")
+      style: secondary
+      start: 19
+      end: 33
+    - source: require("jwt-simple")
+      style: secondary
+      start: 12
+      end: 33
+    - source: jwt = require("jwt-simple")
+      style: secondary
+      start: 6
+      end: 33
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+  ? |-
+    const jwt = require('jwt-simple');
+    const decoded = jwt.decode(token, secret, true);
+  : labels:
+    - source: jwt.decode(token, secret, true)
+      style: primary
+      start: 51
+      end: 82
+    - source: jwt
+      style: secondary
+      start: 6
+      end: 9
+    - source: require
+      style: secondary
+      start: 12
+      end: 19
+    - source: jwt-simple
+      style: secondary
+      start: 21
+      end: 31
+    - source: '''jwt-simple'''
+      style: secondary
+      start: 20
+      end: 32
+    - source: ('jwt-simple')
+      style: secondary
+      start: 19
+      end: 33
+    - source: require('jwt-simple')
+      style: secondary
+      start: 12
+      end: 33
+    - source: jwt = require('jwt-simple')
+      style: secondary
+      start: 6
+      end: 33
+    - source: const jwt = require('jwt-simple');
+      style: secondary
+      start: 0
+      end: 34
+    - source: const jwt = require('jwt-simple');
+      style: secondary
+      start: 0
+      end: 34

--- a/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
@@ -176,3 +176,67 @@ snapshots:
       style: secondary
       start: 0
       end: 34
+  ? |-
+    import jwt from "jwt-simple";
+    const decoded = jwt.decode(token, secret, true);
+  : labels:
+    - source: jwt.decode(token, secret, true)
+      style: primary
+      start: 46
+      end: 77
+    - source: jwt
+      style: secondary
+      start: 7
+      end: 10
+    - source: jwt
+      style: secondary
+      start: 7
+      end: 10
+    - source: jwt-simple
+      style: secondary
+      start: 17
+      end: 27
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 16
+      end: 28
+    - source: import jwt from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 29
+    - source: import jwt from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 29
+  ? |-
+    import jwteq = require("jwt-simple");
+    const decoded = jwteq.decode(token, secret, true);
+  : labels:
+    - source: jwteq.decode(token, secret, true)
+      style: primary
+      start: 54
+      end: 87
+    - source: jwteq
+      style: secondary
+      start: 7
+      end: 12
+    - source: jwt-simple
+      style: secondary
+      start: 24
+      end: 34
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 23
+      end: 35
+    - source: jwteq = require("jwt-simple")
+      style: secondary
+      start: 7
+      end: 36
+    - source: import jwteq = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 37
+    - source: import jwteq = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 37

--- a/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
@@ -2,6 +2,94 @@ id: jwt-simple-noverify-typescript
 snapshots:
   ? |-
     const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, "HS256");
+  : labels:
+    - source: jwt.decode(token, secret, "HS256")
+      style: primary
+      start: 51
+      end: 85
+    - source: jwt
+      style: secondary
+      start: 6
+      end: 9
+    - source: require
+      style: secondary
+      start: 12
+      end: 19
+    - source: jwt-simple
+      style: secondary
+      start: 21
+      end: 31
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 20
+      end: 32
+    - source: ("jwt-simple")
+      style: secondary
+      start: 19
+      end: 33
+    - source: require("jwt-simple")
+      style: secondary
+      start: 12
+      end: 33
+    - source: jwt = require("jwt-simple")
+      style: secondary
+      start: 6
+      end: 33
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+  ? |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, 1);
+  : labels:
+    - source: jwt.decode(token, secret, 1)
+      style: primary
+      start: 51
+      end: 79
+    - source: jwt
+      style: secondary
+      start: 6
+      end: 9
+    - source: require
+      style: secondary
+      start: 12
+      end: 19
+    - source: jwt-simple
+      style: secondary
+      start: 21
+      end: 31
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 20
+      end: 32
+    - source: ("jwt-simple")
+      style: secondary
+      start: 19
+      end: 33
+    - source: require("jwt-simple")
+      style: secondary
+      start: 12
+      end: 33
+    - source: jwt = require("jwt-simple")
+      style: secondary
+      start: 6
+      end: 33
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+  ? |-
+    const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret, true);
   : labels:
     - source: jwt.decode(token, secret, true)

--- a/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
@@ -293,6 +293,50 @@ snapshots:
       start: 0
       end: 37
   ? |-
+    import { decode as jwtDecode } from "jwt-simple";
+    const decoded = jwtDecode(token, secret, true);
+  : labels:
+    - source: jwtDecode(token, secret, true)
+      style: primary
+      start: 66
+      end: 96
+    - source: decode
+      style: secondary
+      start: 9
+      end: 15
+    - source: jwtDecode
+      style: secondary
+      start: 19
+      end: 28
+    - source: decode as jwtDecode
+      style: secondary
+      start: 9
+      end: 28
+    - source: '{ decode as jwtDecode }'
+      style: secondary
+      start: 7
+      end: 30
+    - source: '{ decode as jwtDecode }'
+      style: secondary
+      start: 7
+      end: 30
+    - source: jwt-simple
+      style: secondary
+      start: 37
+      end: 47
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 36
+      end: 48
+    - source: import { decode as jwtDecode } from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 49
+    - source: import { decode as jwtDecode } from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 49
+  ? |-
     import { decode } from "jwt-simple";
     const decoded = decode(token, secret, true);
   : labels:
@@ -300,6 +344,10 @@ snapshots:
       style: primary
       start: 53
       end: 80
+    - source: decode
+      style: secondary
+      start: 9
+      end: 15
     - source: decode
       style: secondary
       start: 9

--- a/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/jwt-simple-noverify-typescript-snapshot.yml
@@ -44,6 +44,58 @@ snapshots:
       style: secondary
       start: 0
       end: 34
+    - source: HS256
+      style: secondary
+      start: 78
+      end: 83
+  ? |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, -1);
+  : labels:
+    - source: jwt.decode(token, secret, -1)
+      style: primary
+      start: 51
+      end: 80
+    - source: jwt
+      style: secondary
+      start: 6
+      end: 9
+    - source: require
+      style: secondary
+      start: 12
+      end: 19
+    - source: jwt-simple
+      style: secondary
+      start: 21
+      end: 31
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 20
+      end: 32
+    - source: ("jwt-simple")
+      style: secondary
+      start: 19
+      end: 33
+    - source: require("jwt-simple")
+      style: secondary
+      start: 12
+      end: 33
+    - source: jwt = require("jwt-simple")
+      style: secondary
+      start: 6
+      end: 33
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+    - source: const jwt = require("jwt-simple");
+      style: secondary
+      start: 0
+      end: 34
+    - source: '1'
+      style: secondary
+      start: 78
+      end: 79
   ? |-
     const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret, 1);
@@ -240,3 +292,43 @@ snapshots:
       style: secondary
       start: 0
       end: 37
+  ? |-
+    import { decode } from "jwt-simple";
+    const decoded = decode(token, secret, true);
+  : labels:
+    - source: decode(token, secret, true)
+      style: primary
+      start: 53
+      end: 80
+    - source: decode
+      style: secondary
+      start: 9
+      end: 15
+    - source: decode
+      style: secondary
+      start: 9
+      end: 15
+    - source: '{ decode }'
+      style: secondary
+      start: 7
+      end: 17
+    - source: '{ decode }'
+      style: secondary
+      start: 7
+      end: 17
+    - source: jwt-simple
+      style: secondary
+      start: 24
+      end: 34
+    - source: '"jwt-simple"'
+      style: secondary
+      start: 23
+      end: 35
+    - source: import { decode } from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 36
+    - source: import { decode } from "jwt-simple";
+      style: secondary
+      start: 0
+      end: 36

--- a/tests/ast-grep/__snapshots__/node-sequelize-empty-password-argument-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/node-sequelize-empty-password-argument-typescript-snapshot.yml
@@ -1,0 +1,310 @@
+id: node-sequelize-empty-password-argument-typescript
+snapshots:
+  ? |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "");
+  : labels:
+    - source: '""'
+      style: primary
+      start: 81
+      end: 83
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", "")
+      style: secondary
+      start: 51
+      end: 84
+    - source: ("mydb", "user", "")
+      style: secondary
+      start: 64
+      end: 84
+  ? |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "", { logging: false });
+  : labels:
+    - source: '""'
+      style: primary
+      start: 81
+      end: 83
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: 'new Sequelize("mydb", "user", "", { logging: false })'
+      style: secondary
+      start: 51
+      end: 104
+    - source: '("mydb", "user", "", { logging: false })'
+      style: secondary
+      start: 64
+      end: 104
+  ? |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", ``);
+  : labels:
+    - source: '``'
+      style: primary
+      start: 81
+      end: 83
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", ``)
+      style: secondary
+      start: 51
+      end: 84
+    - source: ("mydb", "user", ``)
+      style: secondary
+      start: 64
+      end: 84
+  ? |-
+    const Sequelize = require("sequelize");
+    const pw = "";
+    const db = new Sequelize("mydb", "user", pw);
+  : labels:
+    - source: pw
+      style: primary
+      start: 96
+      end: 98
+    - source: Sequelize
+      style: secondary
+      start: 70
+      end: 79
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", pw)
+      style: secondary
+      start: 66
+      end: 99
+    - source: ("mydb", "user", pw)
+      style: secondary
+      start: 79
+      end: 99
+    - source: pw
+      style: secondary
+      start: 46
+      end: 48
+    - source: '""'
+      style: secondary
+      start: 51
+      end: 53
+    - source: pw = ""
+      style: secondary
+      start: 46
+      end: 53
+    - source: const pw = "";
+      style: secondary
+      start: 40
+      end: 54
+    - source: const pw = "";
+      style: secondary
+      start: 40
+      end: 54
+  ? |-
+    const Sequelize = require("sequelize");
+    const pw = ``;
+    const db = new Sequelize("mydb", "user", pw);
+  : labels:
+    - source: pw
+      style: primary
+      start: 96
+      end: 98
+    - source: Sequelize
+      style: secondary
+      start: 70
+      end: 79
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", pw)
+      style: secondary
+      start: 66
+      end: 99
+    - source: ("mydb", "user", pw)
+      style: secondary
+      start: 79
+      end: 99
+    - source: pw
+      style: secondary
+      start: 46
+      end: 48
+    - source: '``'
+      style: secondary
+      start: 51
+      end: 53
+    - source: pw = ``
+      style: secondary
+      start: 46
+      end: 53
+    - source: const pw = ``;
+      style: secondary
+      start: 40
+      end: 54
+    - source: const pw = ``;
+      style: secondary
+      start: 40
+      end: 54
+  ? |-
+    const Sequelize = require("sequelize");
+    var pw = "";
+    const db = new Sequelize("mydb", "user", pw, {});
+  : labels:
+    - source: pw
+      style: primary
+      start: 94
+      end: 96
+    - source: Sequelize
+      style: secondary
+      start: 68
+      end: 77
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", pw, {})
+      style: secondary
+      start: 64
+      end: 101
+    - source: ("mydb", "user", pw, {})
+      style: secondary
+      start: 77
+      end: 101
+    - source: pw
+      style: secondary
+      start: 44
+      end: 46
+    - source: '""'
+      style: secondary
+      start: 49
+      end: 51
+    - source: pw = ""
+      style: secondary
+      start: 44
+      end: 51
+    - source: var pw = "";
+      style: secondary
+      start: 40
+      end: 52
+    - source: var pw = "";
+      style: secondary
+      start: 40
+      end: 52
+  ? |-
+    const Sequelize = require("sequelize");
+    var pw = ``;
+    const db = new Sequelize("mydb", "user", pw, {});
+  : labels:
+    - source: pw
+      style: primary
+      start: 94
+      end: 96
+    - source: Sequelize
+      style: secondary
+      start: 68
+      end: 77
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", pw, {})
+      style: secondary
+      start: 64
+      end: 101
+    - source: ("mydb", "user", pw, {})
+      style: secondary
+      start: 77
+      end: 101
+    - source: pw
+      style: secondary
+      start: 44
+      end: 46
+    - source: '``'
+      style: secondary
+      start: 49
+      end: 51
+    - source: pw = ``
+      style: secondary
+      start: 44
+      end: 51
+    - source: var pw = ``;
+      style: secondary
+      start: 40
+      end: 52
+    - source: var pw = ``;
+      style: secondary
+      start: 40
+      end: 52
+  ? |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', '');
+  : labels:
+    - source: ''''''
+      style: primary
+      start: 81
+      end: 83
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize('mydb', 'user', '')
+      style: secondary
+      start: 51
+      end: 84
+    - source: ('mydb', 'user', '')
+      style: secondary
+      start: 64
+      end: 84

--- a/tests/ast-grep/__snapshots__/node-sequelize-hardcoded-secret-argument-typescript-snapshot.yml
+++ b/tests/ast-grep/__snapshots__/node-sequelize-hardcoded-secret-argument-typescript-snapshot.yml
@@ -1,0 +1,130 @@
+id: node-sequelize-hardcoded-secret-argument-typescript
+snapshots:
+  ? |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "hunter2");
+  : labels:
+    - source: '"hunter2"'
+      style: primary
+      start: 81
+      end: 90
+    - source: hunter2
+      style: secondary
+      start: 82
+      end: 89
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize("mydb", "user", "hunter2")
+      style: secondary
+      start: 51
+      end: 91
+    - source: ("mydb", "user", "hunter2")
+      style: secondary
+      start: 64
+      end: 91
+  ? |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "hunter2", { logging: false });
+  : labels:
+    - source: '"hunter2"'
+      style: primary
+      start: 81
+      end: 90
+    - source: hunter2
+      style: secondary
+      start: 82
+      end: 89
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require("sequelize");
+      style: secondary
+      start: 0
+      end: 39
+    - source: 'new Sequelize("mydb", "user", "hunter2", { logging: false })'
+      style: secondary
+      start: 51
+      end: 111
+    - source: '("mydb", "user", "hunter2", { logging: false })'
+      style: secondary
+      start: 64
+      end: 111
+  ? |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', 'hunter2');
+  : labels:
+    - source: '''hunter2'''
+      style: primary
+      start: 81
+      end: 90
+    - source: hunter2
+      style: secondary
+      start: 82
+      end: 89
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize('mydb', 'user', 'hunter2')
+      style: secondary
+      start: 51
+      end: 91
+    - source: ('mydb', 'user', 'hunter2')
+      style: secondary
+      start: 64
+      end: 91
+  ? |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', 'hunter2', {});
+  : labels:
+    - source: '''hunter2'''
+      style: primary
+      start: 81
+      end: 90
+    - source: hunter2
+      style: secondary
+      start: 82
+      end: 89
+    - source: Sequelize
+      style: secondary
+      start: 55
+      end: 64
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: const Sequelize = require('sequelize');
+      style: secondary
+      start: 0
+      end: 39
+    - source: new Sequelize('mydb', 'user', 'hunter2', {})
+      style: secondary
+      start: 51
+      end: 95
+    - source: ('mydb', 'user', 'hunter2', {})
+      style: secondary
+      start: 64
+      end: 95

--- a/tests/ast-grep/detect-angular-sce-disabled-typescript.yml
+++ b/tests/ast-grep/detect-angular-sce-disabled-typescript.yml
@@ -1,0 +1,9 @@
+id: detect-angular-sce-disabled-typescript
+valid:
+  # Enabling SCE is the safe direction.
+  - |-
+    $sceProvider.enabled(true);
+invalid:
+  # Disabling SCE disables strict contextual escaping.
+  - |-
+    $sceProvider.enabled(false);

--- a/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
+++ b/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
@@ -21,6 +21,10 @@ valid:
   - |-
     const session = require("express-session");
     app.use(session({ secret: [] }));
+  # The module name must be the first argument to require.
+  - |-
+    const session = require("other-module", "express-session");
+    app.use(session({ secret: "hunter2" }));
 invalid:
   # Double-quoted import with inline secret (biome's enforced style).
   - |-

--- a/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
+++ b/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
@@ -13,6 +13,14 @@ valid:
   - |-
     const session = require("not-express-session");
     app.use(session({ secret: "hunter2" }));
+  # An array with no constant element holds no hard-coded credential.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: [process.env.SECRET] }));
+  # An empty array holds no credential at all.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: [] }));
 invalid:
   # Double-quoted import with inline secret (biome's enforced style).
   - |-
@@ -38,6 +46,14 @@ invalid:
   - |-
     const session = require("express-session");
     app.use(session({ secret: `hunter2` }));
+  # Rotation arrays of constant secrets must fire.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: ["hunter2", "old-secret"] }));
+  # A hard-coded fallback inside a rotation array is still a credential.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: [process.env.SECRET, "fallback"] }));
   # Indirect object via const.
   - |-
     const session = require("express-session");

--- a/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
+++ b/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
@@ -54,6 +54,10 @@ invalid:
   - |-
     const session = require("express-session");
     app.use(session({ secret: [process.env.SECRET, "fallback"] }));
+  # Quoted object keys carry the same credential.
+  - |-
+    const session = require("express-session");
+    app.use(session({ "secret": "hunter2" }));
   # Indirect object via const.
   - |-
     const session = require("express-session");

--- a/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
+++ b/tests/ast-grep/express-session-hardcoded-secret-typescript.yml
@@ -1,0 +1,50 @@
+id: express-session-hardcoded-secret-typescript
+valid:
+  # Interpolated templates are not hard-coded, so they must never fire.
+  - |-
+    const session = require("express-session");
+    const s = process.env.SECRET;
+    app.use(session({ secret: `${s}` }));
+  # Env-derived values are not hard-coded.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: process.env.SECRET }));
+  # Wrong module must not fire.
+  - |-
+    const session = require("not-express-session");
+    app.use(session({ secret: "hunter2" }));
+invalid:
+  # Double-quoted import with inline secret (biome's enforced style).
+  - |-
+    import session from "express-session";
+    app.use(session({ secret: "hunter2", resave: false }));
+  # Single-quoted import with inline secret.
+  - |-
+    import session from 'express-session';
+    app.use(session({ secret: 'hunter2', resave: false }));
+  # Double-quoted require with inline secret.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: "hunter2" }));
+  # Single-quoted require with inline secret.
+  - |-
+    const session = require('express-session');
+    app.use(session({ secret: 'hunter2' }));
+  # var require with inline secret.
+  - |-
+    var session = require("express-session");
+    app.use(session({ secret: "hunter2" }));
+  # Constant template secret (no substitution) must fire.
+  - |-
+    const session = require("express-session");
+    app.use(session({ secret: `hunter2` }));
+  # Indirect object via const.
+  - |-
+    const session = require("express-session");
+    const opts = { secret: "hunter2" };
+    app.use(session(opts));
+  # Indirect object via let reassignment.
+  - |-
+    const session = require("express-session");
+    let opts; opts = { secret: "hunter2" };
+    app.use(session(opts));

--- a/tests/ast-grep/jwt-simple-noverify-typescript.yml
+++ b/tests/ast-grep/jwt-simple-noverify-typescript.yml
@@ -1,0 +1,19 @@
+id: jwt-simple-noverify-typescript
+valid:
+  # Two-argument decode has no no-verify flag to pass.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret);
+  # Wrong module must not fire.
+  - |-
+    const jwt = require("jsonwebtoken");
+    const decoded = jwt.decode(token, secret, true);
+invalid:
+  # Single-quoted require with a truthy no-verify argument.
+  - |-
+    const jwt = require('jwt-simple');
+    const decoded = jwt.decode(token, secret, true);
+  # Double-quoted require with a truthy no-verify argument.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, true);

--- a/tests/ast-grep/jwt-simple-noverify-typescript.yml
+++ b/tests/ast-grep/jwt-simple-noverify-typescript.yml
@@ -32,6 +32,10 @@ valid:
   - |-
     jwt = require("other-mod", "jwt-simple");
     const decoded = jwt.decode(token, secret, true);
+  # Logical negation is falsy, so verification still happens.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, !1);
 invalid:
   # Single-quoted require with a truthy no-verify argument.
   - |-
@@ -65,3 +69,7 @@ invalid:
   - |-
     import { decode } from "jwt-simple";
     const decoded = decode(token, secret, true);
+  # An aliased named import binds the local identifier.
+  - |-
+    import { decode as jwtDecode } from "jwt-simple";
+    const decoded = jwtDecode(token, secret, true);

--- a/tests/ast-grep/jwt-simple-noverify-typescript.yml
+++ b/tests/ast-grep/jwt-simple-noverify-typescript.yml
@@ -16,6 +16,18 @@ valid:
   - |-
     const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret, 0x0);
+  # An empty string is falsy, so verification still happens.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, "");
+  # An empty template is falsy too.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, ``);
+  # Negative zero is still zero, so it is falsy.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, -0);
   # The module name must be the first and only string in the require call.
   - |-
     jwt = require("other-mod", "jwt-simple");
@@ -45,3 +57,11 @@ invalid:
   - |-
     import jwteq = require("jwt-simple");
     const decoded = jwteq.decode(token, secret, true);
+  # A negative non-zero number is truthy and skips verification.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, -1);
+  # Named-import destructuring drops the receiver but not the risk.
+  - |-
+    import { decode } from "jwt-simple";
+    const decoded = decode(token, secret, true);

--- a/tests/ast-grep/jwt-simple-noverify-typescript.yml
+++ b/tests/ast-grep/jwt-simple-noverify-typescript.yml
@@ -4,6 +4,10 @@ valid:
   - |-
     const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret);
+  # A falsy no-verify flag still verifies.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, 0);
   # Wrong module must not fire.
   - |-
     const jwt = require("jsonwebtoken");
@@ -17,3 +21,11 @@ invalid:
   - |-
     const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret, true);
+  # Any truthy string skips verification, not just the literal true.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, "HS256");
+  # Any non-zero number is truthy and skips verification.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, 1);

--- a/tests/ast-grep/jwt-simple-noverify-typescript.yml
+++ b/tests/ast-grep/jwt-simple-noverify-typescript.yml
@@ -12,6 +12,14 @@ valid:
   - |-
     const jwt = require("jsonwebtoken");
     const decoded = jwt.decode(token, secret, true);
+  # Hex, binary, and exponent spellings of zero are falsy.
+  - |-
+    const jwt = require("jwt-simple");
+    const decoded = jwt.decode(token, secret, 0x0);
+  # The module name must be the first and only string in the require call.
+  - |-
+    jwt = require("other-mod", "jwt-simple");
+    const decoded = jwt.decode(token, secret, true);
 invalid:
   # Single-quoted require with a truthy no-verify argument.
   - |-
@@ -29,3 +37,11 @@ invalid:
   - |-
     const jwt = require("jwt-simple");
     const decoded = jwt.decode(token, secret, 1);
+  # ES module import binds the module the same way require does.
+  - |-
+    import jwt from "jwt-simple";
+    const decoded = jwt.decode(token, secret, true);
+  # TypeScript import-equals binding of the CommonJS module.
+  - |-
+    import jwteq = require("jwt-simple");
+    const decoded = jwteq.decode(token, secret, true);

--- a/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
+++ b/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
@@ -19,6 +19,10 @@ valid:
   - |-
     const Sequelize = require("sequelize");
     const db = new Sequelize("mydb", "user", "", {}, {});
+  # An interpolated template is not an empty password.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", `${process.env.DB_PASSWORD}`);
 invalid:
   # Three-argument constructor with empty password, double quotes.
   - |-

--- a/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
+++ b/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
@@ -1,0 +1,56 @@
+id: node-sequelize-empty-password-argument-typescript
+valid:
+  # A real password is not an empty one.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "realpw");
+  # A non-empty template password is not empty.
+  - |-
+    const Sequelize = require("sequelize");
+    var pw = `realpw`;
+    const db = new Sequelize("mydb", "user", pw, {});
+  # Env-derived passwords are not hard-coded empties.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", process.env.PW);
+  # Five-argument constructor calls are out of scope.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "", {}, {});
+invalid:
+  # Three-argument constructor with empty password, double quotes.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "");
+  # Three-argument constructor with empty password, single quotes.
+  - |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', '');
+  # Four-argument constructor with empty password.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "", { logging: false });
+  # Empty template password passed directly.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", ``);
+  # const variable holding an empty template password.
+  - |-
+    const Sequelize = require("sequelize");
+    const pw = ``;
+    const db = new Sequelize("mydb", "user", pw);
+  # var variable holding an empty template password.
+  - |-
+    const Sequelize = require("sequelize");
+    var pw = ``;
+    const db = new Sequelize("mydb", "user", pw, {});
+  # var variable holding an empty string password.
+  - |-
+    const Sequelize = require("sequelize");
+    var pw = "";
+    const db = new Sequelize("mydb", "user", pw, {});
+  # const variable holding an empty string password.
+  - |-
+    const Sequelize = require("sequelize");
+    const pw = "";
+    const db = new Sequelize("mydb", "user", pw);

--- a/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
+++ b/tests/ast-grep/node-sequelize-empty-password-argument-typescript.yml
@@ -13,7 +13,9 @@ valid:
   - |-
     const Sequelize = require("sequelize");
     const db = new Sequelize("mydb", "user", process.env.PW);
-  # Five-argument constructor calls are out of scope.
+  # A fifth positional argument is out of scope because Sequelize's
+  # canonical constructor is (database, username, password, options), so
+  # argument three is only known to be the password up to four arguments.
   - |-
     const Sequelize = require("sequelize");
     const db = new Sequelize("mydb", "user", "", {}, {});

--- a/tests/ast-grep/node-sequelize-hardcoded-secret-argument-typescript.yml
+++ b/tests/ast-grep/node-sequelize-hardcoded-secret-argument-typescript.yml
@@ -4,7 +4,9 @@ valid:
   - |-
     const Sequelize = require("sequelize");
     const db = new Sequelize("mydb", "user", process.env.PW);
-  # Five-argument constructor calls are out of scope.
+  # A fifth positional argument is out of scope because Sequelize's
+  # canonical constructor is (database, username, password, options), so
+  # argument three is only known to be the password up to four arguments.
   - |-
     const Sequelize = require("sequelize");
     const db = new Sequelize("mydb", "user", "pw", {}, {});

--- a/tests/ast-grep/node-sequelize-hardcoded-secret-argument-typescript.yml
+++ b/tests/ast-grep/node-sequelize-hardcoded-secret-argument-typescript.yml
@@ -1,0 +1,27 @@
+id: node-sequelize-hardcoded-secret-argument-typescript
+valid:
+  # Env-derived passwords are not hard-coded.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", process.env.PW);
+  # Five-argument constructor calls are out of scope.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "pw", {}, {});
+invalid:
+  # Three-argument constructor with a hard-coded secret, single quotes.
+  - |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', 'hunter2');
+  # Three-argument constructor with a hard-coded secret, double quotes.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "hunter2");
+  # Four-argument constructor with a hard-coded secret, single quotes.
+  - |-
+    const Sequelize = require('sequelize');
+    const db = new Sequelize('mydb', 'user', 'hunter2', {});
+  # Four-argument constructor with a hard-coded secret, double quotes.
+  - |-
+    const Sequelize = require("sequelize");
+    const db = new Sequelize("mydb", "user", "hunter2", { logging: false });


### PR DESCRIPTION
Vendors the TypeScript security subset of `coderabbitai/ast-grep-essentials` (Apache-2.0, license kept in `rules/ESSENTIALS-LICENSE.txt`) into `rules/`, and turns the scanner into a blocking CI gate rather than a review-time hint.

The rules now ship with a snapshot harness: `tests/ast-grep/` records the semantic contract of every rule, and `ast-grep test -t tests/ast-grep` runs in CI, so rule edits and re-vendors are judged against the recorded probe matrix instead of by review alone. `sgconfig.yml` holds the deviation ledger, every local change from upstream with its reason, in one place.

- `scripts/ci.sh` runs `ast-grep scan --error` as a blocking step, so a security-pattern regression fails the build.
- `@ast-grep/cli` 0.45.1 (the version CodeRabbit runs) is a devDependency, pinned because CI runs `npm ci` offline.
- `node-rsa-weak-key` is dropped: its utility key uses reserved characters that 0.45.1 rejects, and the repo does not use node-rsa, so it would only add parse noise.

The review caught real gaps in the upstream rules, arrayed session secrets, quoted secret keys, ES/import-equals/named-import jwt bindings, and numeric/empty-literal truthiness, each fixed and covered by a fixture.